### PR TITLE
Update solution_interface.jl

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -38,7 +38,7 @@ function next(sol::AbstractTimeseriesSolution,state)
 end
 
 function done(sol::AbstractTimeseriesSolution,state)
-  state > length(sol)
+  state >= length(sol)
 end
 
 const DEFAULT_PLOT_FUNC = (x...) -> (x...)


### PR DESCRIPTION
Revert the previous change. `state >= length(sol)` is the correct one, since `next` increments the state before saving it! My bad...