### PR TITLE
MonteCarloSolution always takes converged

### DIFF
--- a/src/solutions/monte_solutions.jl
+++ b/src/solutions/monte_solutions.jl
@@ -6,7 +6,7 @@ type MonteCarloTestSolution{T,N,S} <: AbstractMonteCarloSolution{T,N}
   elapsedTime::Float64
   converged::Bool
 end
-function MonteCarloTestSolution{T,N}(sim::AbstractMonteCarloSolution{T,N},errors,error_means,error_medians)
+function MonteCarloTestSolution{T,N}(sim::AbstractMonteCarloSolution{T,N},errors,error_means,error_medians,converged)
   MonteCarloTestSolution{T,N,typeof(sim.u)}(sim.u,errors,error_means,error_medians,sim.elapsedTime,sim.converged)
 end
 
@@ -19,11 +19,6 @@ MonteCarloSolution{N}(sim, dims::NTuple{N},elapsedTime,converged) =
                   MonteCarloSolution{eltype(eltype(sim)), N, typeof(sim)}(sim,elapsedTime,converged)
 MonteCarloSolution(sim,elapsedTime,converged) =
              MonteCarloSolution(sim, (size(sim[1])..., length(sim)),elapsedTime,converged)
-
-MonteCarloSolution{N}(sim, dims::NTuple{N},elapsedTime) =
-                 MonteCarloSolution{eltype(eltype(sim)), N, typeof(sim)}(sim,elapsedTime,false)
-MonteCarloSolution(sim,elapsedTime,converged) =
-            MonteCarloSolution(sim, (size(sim[1])..., length(sim)),elapsedTime,false)
 
 type MonteCarloSummary{T,N,Tt,S,S2} <: AbstractMonteCarloSolution{T,N}
   t::Tt


### PR DESCRIPTION
I don't think there is any reason `MonteCarloSolution` constructor should work without taking `converged` as an argument. I also forgot about `MonteCarloTestSolution` in the last PR. I guess I should have run tests on both DiffEqBase and my changes to DiffEqMonteCarlo.  I don't think there is anything else I should need to change in base for the basic reduction functionality to work. 