### PR TITLE
Add Dict dispatch for `set_param_value!`

### DIFF
--- a/src/parameters_interface.jl
+++ b/src/parameters_interface.jl
@@ -4,6 +4,11 @@ end
 function set_param_values!(f::AbstractParameterizedFunction,params)
   [setfield!(f,s,p) for (s,p) in zip(f.params,params)]
 end
+function set_param_values!(f::AbstractParameterizedFunction,params::Dict)
+    for (name, value) in params
+        setfield!(f, name, value)
+    end
+end
 num_params(f::AbstractParameterizedFunction) = length(f.params)
 
 # Fallbacks

--- a/test/parameters_interface_test.jl
+++ b/test/parameters_interface_test.jl
@@ -1,0 +1,34 @@
+using OrdinaryDiffEq
+using ParameterizedFunctions
+using DiffEqBase
+using Base.Test
+
+# sweet sweet lorenz equation
+lorenz = @ode_def_bare Lorenz begin
+  dx = σ*(y-x)
+  dy = ρ*x-y-x*z
+  dz = x*y-β*z
+end σ => 10.0 β = 8.0/3.0 ρ => 28.0
+
+# make a clean instance to change
+lorenz_test = Lorenz()
+lorenz_test.params
+
+# make sure we need to provide all the free parameters
+@test_throws DimensionMismatch set_param_values!(lorenz_test, [0.5, 3.2, 5.8])
+@test_throws DimensionMismatch set_param_values!(lorenz_test, [0.5])
+
+# make sure the general setter works
+set_param_values!(lorenz_test, [0.5, 3.2])
+@test lorenz_test.σ == 0.5
+@test lorenz_test.ρ == 3.2
+
+set_param_values!(lorenz_test, Dict(:ρ => 11.3))
+@test lorenz_test.ρ == 11.3
+@test lorenz_test.σ == 0.5
+set_param_values!(lorenz_test, Dict(:σ => -2.1, :ρ => 5.3211115))
+@test lorenz_test.σ == -2.1
+@test lorenz_test.ρ == 5.3211115
+
+# This should throw an error, not sure how to check for it
+#set_param_values!(lorenz_test, Dict(:σ => 6.0, :ρ => 4.3, :β => 1.1))


### PR DESCRIPTION
Added a dispatch option for `set_param_value!` which will give nice options to set parameters for when the `ode_def` macros are used. Also added some basic tests.