### PR TITLE
Fix new DDE problem with changed parameters

### DIFF
--- a/src/parameters_interface.jl
+++ b/src/parameters_interface.jl
@@ -41,7 +41,7 @@ function problem_new_parameters(prob::ConstantLagDDEProblem,p)
   uEltype = eltype(p)
   u0 = [uEltype(prob.u0[i]) for i in 1:length(prob.u0)]
   tspan = (uEltype(prob.tspan[1]),uEltype(prob.tspan[2]))
-  DAEProblem(f,prob.h,u0,prob.lags,tspan)
+  ConstantLagDDEProblem(f,prob.h,u0,prob.lags,tspan)
 end
 param_values(prob::ConstantLagDDEProblem) = param_values(prob.f)
 num_params(prob::ConstantLagDDEProblem) = num_params(prob.f)


### PR DESCRIPTION
Hi!

It seems there is a small typo in the creation of new DDE problems with changed parameters:

```julia
julia> type TestFunction <: AbstractParameterizedFunction{true}
         α::Float64
       end
julia> (f::TestFunction)(t,u,h,du) = f(t,u,h,[f.α],du)
julia> function (f::TestFunction)(t,u,h,p,du)
         du[1] = p[1]*h(t-1)[1]
       end
julia> prob = ConstantLagDDEProblem(TestFunction(1),t->ones(1),[1.],[1.],(0.,10.))
julia> prob2 = problem_new_parameters(prob,[2.])
ERROR: MethodError: no method matching DiffEqBase.DAEProblem(::DiffEqBase.##250#252{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,TestFunction,##1#2,Void,UniformScaling{Int64}},Array{Float64,1}}, ::##1#2, ::Array{Float64,1}, ::Array{Float64,1}, ::Tuple{Float64,Float64})
Closest candidates are:
  DiffEqBase.DAEProblem(::Any, ::Any, ::Any, ::Any; iip, callback, differential_vars) at /home/david/.julia/v0.6/DiffEqBase/src/problems/dae_problems.jl:15
Stacktrace:
 [1] problem_new_parameters(::DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,TestFunction,##1#2,Void,UniformScaling{Int64}}, ::Array{Float64,1}) at /home/david/.julia/v0.6/DiffEqBase/src/parameters_interface.jl:44
```

This error is fixed by the proposed simple change.