### PR TITLE
Indexing and broadcasting changes for DEDataArray

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -4,8 +4,10 @@ module DiffEqBase
 
 using RecipesBase, SimpleTraits, RecursiveArrayTools, Compat, Juno, LinearMaps
 
-import Base: length, ndims, size, getindex, setindex!, endof, show, print,
-             next, start, done, eltype, eachindex, similar
+import Base: length, ndims, size, getindex, setindex!, show, print,
+             next, start, done, similar, IndexStyle
+
+import Base.Broadcast: _containertype, promote_containertype, broadcast_c, broadcast_c!
 
 import Base: resize!, deleteat!
 

--- a/test/data_array_tests.jl
+++ b/test/data_array_tests.jl
@@ -1,0 +1,39 @@
+using DiffEqBase, Base.Test
+
+type VectorType{T} <: DEDataArray{T}
+    x::Vector{T}
+    f::T
+end
+
+type MatrixType{T,S} <: DEDataArray{T}
+    x::Matrix{T}
+    f::S
+end
+
+a = VectorType{Float64}([0.0; 1.0], 2.0)
+b = MatrixType{Int,Float64}([1  2; 4  3], 3.0)
+
+# basic methods of AbstractArray interface
+@test eltype(a) == Float64 && eltype(b) == Int
+@test length(a) == 2 && size(a) == (2,) && eachindex(a) == Base.OneTo(2)
+@test length(b) == 4 && size(b) == (4,) && eachindex(b) == Base.OneTo(4)
+@test first(a) == 0.0 && last(a) == 1.0
+@test first(b) == 1 && last(b) == 3
+
+# simple broadcasts
+@test a .+ [1  2; 4  3] == [1.0  2.0; 5.0  4.0]
+@test [0.0; 1.0] .+ b == [1.0  2.0; 5.0  4.0]
+@test [1//2] .* a == [0.0; 0.5]
+@test b ./ 2 ==  [0.5  1.0; 2.0  1.5]
+@test_throws MethodError a .+ b
+
+a2 = similar(a)
+@test a.x == a2.x && a.f == a2.f
+
+# broadcast assignments
+a2.f = 3
+a .= a .+ a2
+@test a == VectorType{Float64}([0.0; 2.0], 2.0)
+
+b .= b.^2
+@test b == MatrixType{Int,Float64}([1  4; 16  9], 3.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DiffEqBase
 using Base.Test
 
 @time @testset "Number of Parameters Calculation" begin include("numargs_test.jl") end
+@time @testset "Data arrays" begin include("data_array_tests.jl") end
 @time @testset "Solution Interface" begin include("solution_get_tests.jl") end
 @time @testset "Extended Functions" begin include("extended_function_tests.jl") end
 @time @testset "Callbacks" begin include("callbacks.jl") end


### PR DESCRIPTION
I changed the default implementation of `size` and removed the multidimensional indexing operations. Since DEDataArray is a subtype of AbstractVector it should act like a one-dimensional vector in my opinion, and not propagate size and indices of `x`.

This is shown by the following example on the current master branch:
```julia
julia> using DiffEqBase
julia> type MatrixType{T,S} <: DEDataArray{T}
           x::Matrix{T}
           f::S
       end
julia> b = MatrixType{Int,Float64}([1  2; 4  3], 3.0)
2×2 MatrixType{Int64,Float64}:
 1
 4
julia> b.x
2×2 Array{Int64,2}:
 1  2
 4  3
julia> b.^2
2×2 Array{Int64,2}:
  1   1
 16  16
julia> b .= b .+ 2
2×2 MatrixType{Int64,Float64}:
 5
 8
julia> b.x
2×2 Array{Int64,2}:
 5  2
 8  3
julia> b.+b.x
2×2 Array{Int64,2}:
 10   7
 16  11
```
so broadcasting works as expected but only along the first dimension; I assume this happens since `MatrixType` is an `AbstractVector`, and hence only the size of the first dimension is respected which equals 2.

Correcting the indices and size of DEDataArray gives:
```julia
julia> using DiffEqBase
julia> type MatrixType{T,S} <: DEDataArray{T}
           x::Matrix{T}
           f::S
       end
julia> b = MatrixType{Int,Float64}([1  2; 4  3], 3.0)
4-element MatrixType{Int64,Float64}:
 1
 4
 2
 3
julia> b.x
2×2 Array{Int64,2}:
 1  2
 4  3
julia> b.^2
4-element Array{Int64,1}:
  1
 16
  4
  9
julia> b .= b .+ 2
4-element MatrixType{Int64,Float64}:
 3
 6
 4
 5
julia> b.x
2×2 Array{Int64,2}:
 3  4
 6  5
julia> b.+b.x
ERROR: DimensionMismatch("arrays could not be broadcast to a common size")
Stacktrace:
 [1] _bcs1(::Base.OneTo{Int64}, ::Base.OneTo{Int64}) at ./broadcast.jl:70
 [2] _bcs at ./broadcast.jl:63 [inlined]
 [3] broadcast_shape at ./broadcast.jl:57 [inlined] (repeats 2 times)
 [4] broadcast_indices at ./broadcast.jl:53 [inlined]
 [5] broadcast_c at ./broadcast.jl:311 [inlined]
 [6] broadcast(::Function, ::MatrixType{Int64,Float64}, ::Array{Int64,2}) at ./broadcast.jl:434
```
So everything works as expected, but only for vectors even though the underlying array `x` is a matrix. The question is whether this is desirable or not.

If this behaviour is intended, the following changes can be removed again, and everything works as expected. Otherwise, if we would rather broadcast on `x` instead of the vector wrapper defined by DEDataArray I added some simple implementations of `_containertype`, `_promote_containertype`, `broadcast_c`, and `broadcast_c!`. I'm not sure whether this is the correct way to implement broadcast methods, I just followed the advice given at https://discourse.julialang.org/t/broadcast-for-custom-type/3497/3.

This then leads to the following behaviour:
```julia
julia> using DiffEqBase
julia> type MatrixType{T,S} <: DEDataArray{T}
           x::Matrix{T}
           f::S
       end
julia> b = MatrixType{Int,Float64}([1  2; 4  3], 3.0)
4-element MatrixType{Int64,Float64}:
 1
 4
 2
 3
julia> b.x
2×2 Array{Int64,2}:
 1  2
 4  3
julia> b.^2
2×2 Array{Int64,2}:
  1  4
 16  9
julia> b .= b .+ 2
4-element MatrixType{Int64,Float64}:
 3
 6
 4
 5
julia> b.x
2×2 Array{Int64,2}:
 3  4
 6  5
julia> b.+b.x
2×2 Array{Int64,2}:
  6   8
 12  10
```