### PR TITLE
Change DEDataArray implementation

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -4,8 +4,8 @@ module DiffEqBase
 
 using RecipesBase, SimpleTraits, RecursiveArrayTools, Compat, Juno, LinearMaps
 
-import Base: length, ndims, size, getindex, setindex!, endof, show, print,
-             next, start, done, eltype, eachindex, similar
+import Base: length, size, getindex, setindex!, show, print,
+             next, start, done, similar, indices
 
 import Base: resize!, deleteat!
 
@@ -85,9 +85,13 @@ abstract type AbstractDiffEqInterpolation <: Function end
 abstract type AbstractDEOptions end
 abstract type DECache end
 abstract type DECallback end
-abstract type DEDataArray{T} <: AbstractVector{T} end
 
-export AbstractDiffEqInterpolation, AbstractDEOptions, DECache, DECallback, DEDataArray
+abstract type DEDataArray{T,N} <: AbstractArray{T,N} end
+const DEDataVector{T} = DEDataArray{T,1}
+const DEDataMatrix{T} = DEDataArray{T,2}
+
+export AbstractDiffEqInterpolation, AbstractDEOptions, DECache, DECallback, DEDataArray,
+       DEDataVector, DEDataMatrix
 
 # Integrators
 abstract type DEIntegrator end
@@ -205,6 +209,8 @@ export resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,
        savevalues!
 
 export numargs, @def
+
+export recursivecopy!, copy_fields, copy_fields!
 
 export construct_correlated_noisefunc
 

--- a/test/data_array_tests.jl
+++ b/test/data_array_tests.jl
@@ -1,0 +1,75 @@
+using DiffEqBase, Base.Test
+
+type VectorType{T} <: DEDataVector{T}
+    x::Vector{T}
+    f::T
+end
+
+type MatrixType{T,S} <: DEDataMatrix{T}
+    f::S
+    x::Matrix{T}
+end
+
+A = [0.0; 1.0]
+B = [1  2; 4  3]
+
+a = VectorType{Float64}(copy(A), 1.0)
+b = MatrixType{Int,Float64}(2.0, copy(B))
+
+# basic methods of AbstractArray interface
+@test eltype(a) == Float64 && eltype(b) == Int
+
+# size
+@test length(a) == 2 && length(b) == 4
+@test size(a) == (2,) && size(b) == (2,2)
+
+# iteration
+@test first(a) == 0.0 && first(b) == 1
+@test last(a) == 1.0 && last(b) == 3
+
+# indexing
+@test eachindex(a) == Base.linearindices(A) && eachindex(b) == Base.linearindices(B)
+@test a[2] == a[end] == 1.0
+@test b[3] == b[1,2] == 2 && b[:, 1] == [1; 4]
+
+a[1] = 3; b[2,1] = 1
+@test a[1] == 3.0 && b[2] == 1
+
+a[:] = A; b[:, 1] = B[1:2]
+@test a.x == A && b.x == B
+
+# simple broadcasts
+@test [1//2] .* a == [0.0; 0.5]
+@test b ./ 2 ==  [0.5  1.0; 2.0  1.5]
+@test a .+ b == [1.0  2.0; 5.0  4.0]
+
+# similar data arrays
+a2 = similar(a); b2 = similar(b, (1,4)); b3 = similar(b, Float64, (1, 4))
+@test typeof(a2.x) == Vector{Float64} && a2.f == 1.0
+@test typeof(b2.x) == Matrix{Int} && b2.f == 2.0
+@test typeof(b3.x) == Matrix{Float64} && b3.f == 2.0
+
+# copy all fields of data arrays
+DiffEqBase.recursivecopy!(a2, a)
+DiffEqBase.recursivecopy!(b2, b)
+@test a2.x == A && vec(b2.x) == vec(B)
+@test_throws MethodError DiffEqBase.recursivecopy!(b3, b)
+
+# copy all fields except of field x
+a2.f = 3.0; b2.f = -1; b3.f == 0
+DiffEqBase.copy_fields!(a, a2)
+DiffEqBase.copy_fields!(b, b2)
+@test a.f == 3.0 && b.f == -1.0
+@test_throws MethodError DiffEqBase.copy_fields!(b, b3)
+
+# create data array with field x replaced by new array
+a3 = DiffEqBase.copy_fields([1.0; 0.0], a)
+@test a3 == VectorType{Float64}([1; 0], 3.0)
+
+# broadcast assignments
+a.f = 0.0
+a .= a2 .+ a3
+@test a == VectorType{Float64}([1.0; 1.0], 0.0)
+
+b .= b .^ 2 .+ a3
+@test b == MatrixType{Int,Float64}(-1.0, [2  5; 16  9])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DiffEqBase
 using Base.Test
 
 @time @testset "Number of Parameters Calculation" begin include("numargs_test.jl") end
+@time @testset "Data Arrays" begin include("data_array_tests.jl") end
 @time @testset "Solution Interface" begin include("solution_get_tests.jl") end
 @time @testset "Extended Functions" begin include("extended_function_tests.jl") end
 @time @testset "Callbacks" begin include("callbacks.jl") end


### PR DESCRIPTION
These are some changes to `DEDataArray` we discussed in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/64. Since the implementation here is quite different to the other PR and does not contain any specific broadcast methods, I thought it might be cleaner to open a separate PR and close the old one.

`DEDataArray{T,N}` is now a subtype of `AbstractArray{T,N}`, which seems more natural. Of course, if the wrapped array `x` is not of type `AbstractArray{T,N}` the desired behaviour and propagation of `x` won't work but I guess that's a problem the user has to deal with.

Moreover I defined the convenient aliases `DEDataVector` and `DEDataMatrix`. I removed unneeded methods of the AbstractArray interface which will just work because of their defaults in Base, so e.g. only one implementation of `similar` is needed and also indexing can be defined in a more general way which would also work for nonlinear indices. The default behaviour of `similar(A::DEDataArray)` is changed, now instead of a deep copy of `A` it returns a DEDataArray that wraps `similar(A.x)` with a deep copy of all other fields. The old implementations of `similar` with multiple arguments (that are removed) already showed the same behaviour - so there was an inconsistency between the simple and more advanced cases.

The name of `copy_non_array_fields(!)` was misleading since it copies arrays, only array `x` is excluded. So I renamed it to `copy_fields(!)` but I'd like to hear your suggestions since also this name does not seem to fit perfectly. Moreover, `x` was always assumed to be the first argument of the constructor; this is changed, now creation of a new `DEDataArray` with an array `arr` and a `DEDataArray` template calls the constructor with `arr` always at its correct position. Another minor change is that `recursivecopy!` and `copy_non_array_fields(!)` now copy also fields that are not arrays (before they were just set to the value of the source).

Oh, and the example in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/64 gives:
```julia
julia> using DiffEqBase
julia> type MatrixType{T,S} <: DEDataMatrix{T}
                  x::Matrix{T}
                  f::S
              end
julia> b = MatrixType{Int,Float64}([1  2; 4  3], 3.0)
2×2 MatrixType{Int64,Float64}:
 1  2
 4  3
julia> b.x
2×2 Array{Int64,2}:
 1  2
 4  3
julia> b.^2
2×2 Array{Int64,2}:
  1  4
 16  9
julia> b .= b .+ 2
2×2 MatrixType{Int64,Float64}:
 3  4
 6  5
julia> b.x
2×2 Array{Int64,2}:
 3  4
 6  5
julia> b.+b.x
2×2 Array{Int64,2}:
  6   8
 12  10
```