### PR TITLE
Implemented size method for AffineDiffEqOperators

### DIFF
--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -65,9 +65,13 @@ struct AffineDiffEqOperator{T,T1,T2,U} <: AbstractDiffEqOperator{T}
     Bs::T2
     u_cache::U
     function AffineDiffEqOperator{T}(As,Bs,u_cache=nothing) where T
+        all([size(a) == size(As[1])
+             for a in As]) || error("Operator sizes do not agree")
         new{T,typeof(As),typeof(Bs),typeof(u_cache)}(As,Bs,u_cache)
     end
 end
+
+Base.size(L::AffineDiffEqOperator) = size(L.As[1])
 
 
 function (L::AffineDiffEqOperator)(t::Number,u)

--- a/test/affine_operators_tests.jl
+++ b/test/affine_operators_tests.jl
@@ -1,0 +1,18 @@
+using DiffEqBase
+using Base.Test
+
+mutable struct TestDiffEqOperator{T} <: AbstractDiffEqLinearOperator{T}
+    m::Int
+    n::Int
+end
+
+TestDiffEqOperator{T}(A::AbstractMatrix{T}) =
+    TestDiffEqOperator{T}(size(A)...)
+
+Base.size(A::TestDiffEqOperator) = (A.m, A.n)
+
+
+A = TestDiffEqOperator([0 0; 0 1])
+B = TestDiffEqOperator([0 0 0; 0 1 0; 0 0 2])
+
+@test_throws ErrorException AffineDiffEqOperator{Int64}((A,B),())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,4 @@ using Base.Test
 @time @testset "Constructed Parameterized Functions" begin include("constructed_pf_test.jl") end
 @time @testset "Plot Variables" begin include("plot_vars.jl") end
 @time @testset "Problem Creation Tests" begin include("problem_creation_tests.jl") end
+@time @testset "Affine differential equation operators" begin include("affine_operators_tests.jl") end


### PR DESCRIPTION
`size` is necessary for F*u. The sizes of the constituent operators
have to agree as well, for the sum to be defined.

NB. To not depend on OrdinaryDiffEq.jl for testing, I implemented a dummy operator consisting only of size information.