### PR TITLE
Linear ops traits

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -265,7 +265,8 @@ export is_diagonal_noise, is_sparse_noise
 
 export LinSolveFactorize, DEFAULT_LINSOLVE
 
-export AffineDiffEqOperator, update_coefficients!, update_coefficients, is_constant
+export AffineDiffEqOperator, update_coefficients!, update_coefficients, is_constant,
+       has_expmv!, has_expmv, has_expm, has_mul, has_mul!, has_ldiv, has_ldiv!
 
 export isautodifferentiable
 

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -44,6 +44,7 @@ is_constant(L::AbstractDiffEqLinearOperator) = true
 # Other ones from LinearMaps.jl
 # Generic fallbacks
 Base.expm(L::AbstractDiffEqLinearOperator,t) = expm(t*L)
+has_expm(L::AbstractDiffEqLinearOperator,t) = true
 expmv(L::AbstractDiffEqLinearOperator,t,u) = expm(t,L)*u
 expmv!(v,L::AbstractDiffEqLinearOperator,t,u) = A_mul_B!(v,expm(t,L),u)
 # Factorizations have no fallback and just error

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -12,6 +12,16 @@
 update_coefficients!(L,t,u) = nothing
 update_coefficients(L,t,u) = L
 
+# Traits
+is_constant(L::AbstractDiffEqOperator) = false
+has_expmv!(L::AbstractDiffEqOperator) = false # expmv!(v, L, t, u)
+has_expmv(L::AbstractDiffEqOperator) = false # v = expm(L, t, u)
+has_expm(L::AbstractDiffEqOperator) = false # v = expm(L, t)*u
+has_mul(L::AbstractDiffEqOperator) = true # du = L*u
+has_mul!(L::AbstractDiffEqOperator) = false # A_mul_B!(du, L, u)
+has_ldiv(L::AbstractDiffEqOperator) = false # du = L\u
+has_ldiv!(L::AbstractDiffEqOperator) = false # A_ldiv_B!(du, L, u)
+
 ### AbstractDiffEqLinearOperator Interface
 
 #=


### PR DESCRIPTION
Should there be more traits?

I chose not to set `has_expmv(!)` for `AbstractDiffEqLinearOperator` since they fall back on the less efficient `expm`.