### PR TITLE
Add AbstractContinuousCallback

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -5,7 +5,7 @@ module DiffEqBase
 using RecipesBase, SimpleTraits, RecursiveArrayTools, Compat, Juno, LinearMaps
 
 import Base: length, size, getindex, setindex!, show, print,
-             next, start, done, similar, indices
+             next, start, done, similar, indices, A_ldiv_B!
 
 import Base: resize!, deleteat!
 
@@ -93,13 +93,14 @@ abstract type AbstractDiffEqInterpolation <: Function end
 abstract type AbstractDEOptions end
 abstract type DECache end
 abstract type DECallback end
+abstract type AbstractContinuousCallback <: DECallback end
 
 abstract type DEDataArray{T,N} <: AbstractArray{T,N} end
 const DEDataVector{T} = DEDataArray{T,1}
 const DEDataMatrix{T} = DEDataArray{T,2}
 
-export AbstractDiffEqInterpolation, AbstractDEOptions, DECache, DECallback, DEDataArray,
-       DEDataVector, DEDataMatrix
+export AbstractDiffEqInterpolation, AbstractDEOptions, DECache, DECallback,
+       AbstractContinuousCallback, DEDataArray, DEDataVector, DEDataMatrix
 
 # Integrators
 abstract type DEIntegrator end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,6 +1,6 @@
 INITIALIZE_DEFAULT(cb,t,u,integrator) = nothing
 
-struct ContinuousCallback{F1,F2,F3,F4,T,T2,I} <: DECallback
+struct ContinuousCallback{F1,F2,F3,F4,T,T2,I} <: AbstractContinuousCallback
   condition::F1
   affect!::F2
   affect_neg!::F3
@@ -58,7 +58,7 @@ struct CallbackSet{T1<:Tuple,T2<:Tuple} <: DECallback
 end
 
 CallbackSet(callback::DiscreteCallback) = CallbackSet((),(callback,))
-CallbackSet(callback::ContinuousCallback) = CallbackSet((callback,),())
+CallbackSet(callback::AbstractContinuousCallback) = CallbackSet((callback,),())
 CallbackSet() = CallbackSet((),())
 CallbackSet(cb::Void) = CallbackSet()
 
@@ -67,7 +67,7 @@ CallbackSet(callbacks::Union{DECallback,Void}...) = CallbackSet(split_callbacks(
 
 @inline split_callbacks(cs, ds) = cs, ds
 @inline split_callbacks(cs, ds, c::Void, args...) = split_callbacks(cs, ds, args...)
-@inline split_callbacks(cs, ds, c::ContinuousCallback, args...) = split_callbacks((cs..., c), ds, args...)
+@inline split_callbacks(cs, ds, c::AbstractContinuousCallback, args...) = split_callbacks((cs..., c), ds, args...)
 @inline split_callbacks(cs, ds, d::DiscreteCallback, args...) = split_callbacks(cs, (ds..., d), args...)
 @inline function split_callbacks(cs, ds, d::CallbackSet, args...)
   split_callbacks((cs...,d.continuous_callbacks...), (ds..., d.discrete_callbacks...), args...)

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -71,4 +71,5 @@ end
 
 ################# Overloads for stiff solvers ##################################
 
-Base.A_ldiv_B!(A::DEDataArray,F::Factorization, B::DEDataArray) = A_ldiv_B!(A.x,F,B.x)
+A_ldiv_B!(A::DEDataArray,F::Factorization, B::DEDataArray) = A_ldiv_B!(A.x,F,B.x)
+A_ldiv_B!(F::Factorization, B::DEDataArray) = A_ldiv_B!(F, B.x)


### PR DESCRIPTION
This adds an abstract type of continuous callbacks which helps to add a special subtype of continuous callbacks to track discontinuities in DelayDiffEq.

https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/186, and hence also https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/34 and https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/35 depend on this PR.