### PR TITLE
Implement parameter interface for DDEProblem

### DIFF
--- a/src/parameters_interface.jl
+++ b/src/parameters_interface.jl
@@ -51,6 +51,16 @@ end
 param_values(prob::ConstantLagDDEProblem) = param_values(prob.f)
 num_params(prob::ConstantLagDDEProblem) = num_params(prob.f)
 
+function problem_new_parameters(prob::DDEProblem,p)
+  f = (t,u,h,du) -> prob.f(t,u,h,p,du)
+  uEltype = eltype(p)
+  u0 = [uEltype(prob.u0[i]) for i in 1:length(prob.u0)]
+  tspan = (uEltype(prob.tspan[1]),uEltype(prob.tspan[2]))
+  DDEProblem(f,prob.h,u0,tspan,prob.constant_lags,prob.dependent_lags)
+end
+param_values(prob::DDEProblem) = param_values(prob.f)
+num_params(prob::DDEProblem) = num_params(prob.f)
+
 function problem_new_parameters(prob::SDEProblem,p)
   fpars = num_params(prob.f)
   if fpars > 0


### PR DESCRIPTION
During parameter estimation I discovered that the parameter interface is not implemented for `DDEProblem`. E.g. in DiffEqParamEstim in line
https://github.com/JuliaDiffEq/DiffEqParamEstim.jl/blob/master/src/build_loss_objective.jl#L43
an implementation of `num_params` is required, which currently uses the fallback of `0` for `DDEProblem`. I added the usual implementation. I haven't tested the new problem generator function since I work with a custom generator.