### PR TITLE
Add linearindices method to DEDataArray

### DIFF
--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -17,6 +17,7 @@ end
     @inbounds A.x[I...] = x
 end
 indices(A::DEDataArray) = indices(A.x)
+Base.linearindices(A::DEDataArray) = linearindices(A.x)
 Base.IndexStyle(::Type{<:DEDataArray}) = Base.IndexLinear()
 
 # similar data arrays


### PR DESCRIPTION
Some functions of Base make use of `linearindices`, for example `sum`. The abstract fallback method was slower. For small arrays the difference is significant. Here `a` is a wrapped array, and `b` an `Array` with the same content of `a`. They are both 3x4 Complex128 arrays.

```
julia> @benchmark sum($a)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     19.417 ns (0.00% GC)
  median time:      19.431 ns (0.00% GC)
  mean time:        19.491 ns (0.00% GC)
  maximum time:     51.550 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998

julia> @benchmark sum($b)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.747 ns (0.00% GC)
  median time:      9.800 ns (0.00% GC)
  mean time:        10.134 ns (0.00% GC)
  maximum time:     48.439 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```