### PR TITLE
Add update warning

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,33 @@
+infomsg = """
+~~~ DifferentialEquations.jl *BREAKING* changes  ~~~
+
+We have changed the front-end API on how
+users may define equations of motion and 
+problems, for all problem types that can
+be used in the DifferentialEquations.jl.
+These are *BREAKING* changes, and they
+also have *NO WARNINGS*!
+
+Please see our latest documentation here:
+http://docs.juliadiffeq.org/latest/
+
+or the blogpost that describes the changes:
+http://juliadiffeq.org/2018/01/24/Parameters.html
+
+In short, the mutated argument is the first argument,
+and parameters are now directly passed
+into the equations of motion function. For all
+types now mutation goes first, then dependent variables, 
+then parameters, then independent variables. 
+
+`f(mutated, dependent variables, p/integrator, independent variables)`
+
+For example, this means that the ODE syntax will be `f(u,p,t)` (for the
+out-of-place) and `f(du,u,p,t)` (for the in-place). Notice
+that this change also removes the need for ParameterizedFunctions
+as now parameters are part of the equations of motion.
+
+For more details please visit the above links!
+"""
+
+info(infomsg)


### PR DESCRIPTION
(requires new tag release to take effect)

This message is displayed as an info when a user updates `DiffEqBase` (so, *any* package of the ecosystem).

It is displayed only once, during the update, because the script here triggers the "Pkg.build" after the update.

*I am not sure whether this is triggered multiple times if one updates multiple times.* I am sure however that this does not trigger on `using ...`, only updates.