### PR TITLE
WIP Add TableTraits.jl interface for solutions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,6 @@ Compat 0.19.0
 Requires
 LinearMaps
 FunctionWrappers
+IteratorInterfaceExtensions 0.0.2
+TableTraits 0.0.3
+NamedTuples 4.0.0

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -3,7 +3,8 @@ __precompile__()
 module DiffEqBase
 
 using RecipesBase, SimpleTraits, RecursiveArrayTools, Compat,
-      LinearMaps, FunctionWrappers, Requires
+      LinearMaps, FunctionWrappers, Requires, TableTraits,
+      IteratorInterfaceExtensions, NamedTuples
 
 import Base: length, size, getindex, setindex!, show, print,
              next, start, done, similar, indices, A_ldiv_B!
@@ -203,6 +204,7 @@ include("common_defaults.jl")
 include("data_array.jl")
 include("internal_euler.jl")
 include("juno_rendering.jl")
+include("tabletraits.jl")
 
 export NSODEFunction
 

--- a/src/internal_euler.jl
+++ b/src/internal_euler.jl
@@ -22,7 +22,6 @@ function DiffEqBase.solve(prob::AbstractODEProblem{uType,tType,isinplace},
     f = prob.f
     tspan = prob.tspan
     p = prob.p
-    @assert !isinplace "Only out of place functions supported"
 
     if isempty(tstops)
         tstops = tspan[1]:dt:tspan[2]
@@ -32,10 +31,16 @@ function DiffEqBase.solve(prob::AbstractODEProblem{uType,tType,isinplace},
     nt = length(tstops)
     out = Vector{uType}(nt)
     out[1] = copy(u0)
+    tmp = copy(u0)
     for i=2:nt
         t = tstops[i]
         dt = t-tstops[i-1]
-        out[i] = out[i-1] + dt*f(out[i-1],p,t)
+        if isinplace
+            f(tmp,out[i-1],p,t)
+            out[i] = out[i-1] + dt*tmp
+        else
+            out[i] = out[i-1] + dt*f(out[i-1],p,t)
+        end
     end
     # make solution type
     build_solution(prob, Alg, tstops, out)

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -1,0 +1,89 @@
+struct DESolutionIterator{T,S}
+    sol::S
+end
+
+IteratorInterfaceExtensions.isiterable(sol::DESolution) = true
+TableTraits.isiterabletable(sol::DESolution) = true
+
+function IteratorInterfaceExtensions.getiterator(sol::DESolution)
+    timestamp_type = eltype(sol.t)
+    value_type = eltype(sol.u)
+
+    value_types = Type[]
+    value_names = Symbol[]
+
+    if value_type<:AbstractArray
+        for i in 1:length(sol.u[1])
+            push!(value_types, eltype(sol.u[1]))
+            if has_syms(sol.prob.f)
+                push!(value_names, sol.prob.f.syms[i])
+            else
+                push!(value_names, Symbol("value$i"))
+            end
+        end            
+    else
+        push!(value_types, value_type)
+        if has_syms(sol.prob.f)
+            push!(value_names, sol.prob.f.syms[1])
+        else
+            push!(value_names, :value)
+        end
+    end
+
+    col_expressions = Array{Expr,1}()
+
+    # Add timestamp column
+    push!(col_expressions, Expr(:(::), :timestamp, timestamp_type))
+
+    for i in 1:length(value_types)
+        push!(col_expressions, Expr(:(::), value_names[i], value_types[i]))
+    end
+    
+    t_expr = NamedTuples.make_tuple(col_expressions)
+
+    t2 = :(DESolutionIterator{Float64,Float64})
+    t2.args[2] = t_expr
+    t2.args[3] = typeof(sol)
+
+    t = eval(t2)
+
+    si = t(sol)
+
+    return si
+end
+
+function Base.length(iter::DESolutionIterator)
+    return length(iter.sol)
+end
+
+function Base.eltype(iter::DESolutionIterator{T,S}) where {T,S}
+    return T
+end
+
+Base.eltype(::Type{DESolutionIterator{T,TS}}) where {T,TS} = T
+
+function Base.start(iter::DESolutionIterator)
+    return 1
+end
+
+@generated function Base.next(iter::DESolutionIterator{T,S}, state) where {T,S}
+    constructor_call = Expr(:call, :($T))
+    push!(constructor_call.args, :(iter.sol.t[i]))
+    for i in 1:length(T.parameters)-1
+        if length(T.parameters)>2
+            push!(constructor_call.args, :(iter.sol.u[i][$i]))
+        else
+            push!(constructor_call.args, :(iter.sol.u[i]))
+        end
+    end
+
+    quote
+        i = state
+        a = $constructor_call
+        return a, state+1
+    end
+end
+
+function Base.done(iter::DESolutionIterator, state)
+    return state>length(iter.sol)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ tic()
 @time @testset "Plot Variables" begin include("plot_vars.jl") end
 @time @testset "Problem Creation Tests" begin include("problem_creation_tests.jl") end
 @time @testset "Affine differential equation operators" begin include("affine_operators_tests.jl") end
+@time @testset "TableTraits" begin include("tabletraits_tests.jl") end
 toc()

--- a/test/tabletraits_tests.jl
+++ b/test/tabletraits_tests.jl
@@ -1,5 +1,4 @@
 using DiffEqBase, DiffEqBase.InternalEuler
-using ParameterizedFunctions
 using IteratorInterfaceExtensions
 using Base.Test
 
@@ -19,14 +18,17 @@ array = collect(getiterator(sol))
 @test length(array) == 17
 @test fieldnames(array[1]) == [:timestamp, :value1, :value2]
 
-f_2dlinear_named = @ode_def LotkaVolterra begin
-    dx = 1.5*x - 1*x*y
-    dy = -3*y + 1*x*y
+struct LotkaVolterra
+    syms::Vector{Symbol}
 end
-  
+function (::LotkaVolterra)(du,u,p,t)
+    du[1] = 1.5*u[1] - 1*u[1]*u[2]
+    du[2] = -3*u[2] + 1*u[1]*u[2]
+end
+f_2dlinear_named = LotkaVolterra([:x,:y])
 prob = ODEProblem(f_2dlinear_named,[1.0,1.0],(0.0,1.0))
-sol =solve(prob,Tsit5())
+sol =solve(prob,InternalEuler.FwdEulerAlg(),dt=0.1)
 array = collect(getiterator(sol))
 
-@test length(array) == 7
+@test length(array) == 11
 @test fieldnames(array[1]) == [:timestamp, :x, :y]

--- a/test/tabletraits_tests.jl
+++ b/test/tabletraits_tests.jl
@@ -1,0 +1,32 @@
+using DiffEqBase, DiffEqBase.InternalEuler
+using ParameterizedFunctions
+using IteratorInterfaceExtensions
+using Base.Test
+
+f_1dlinear = (u,p,t) -> 1.01u
+prob = ODEProblem(f_1dlinear,rand(),(0.0,1.0))
+sol =solve(prob,InternalEuler.FwdEulerAlg();dt=1//2^(4))
+array = collect(getiterator(sol))
+
+@test length(array) == 17
+@test fieldnames(array[1]) == [:timestamp, :value]
+
+f_2dlinear = (du,u,p,t) -> du.=1.01u
+prob = ODEProblem(f_2dlinear,rand(2),(0.0,1.0))
+sol =solve(prob,InternalEuler.FwdEulerAlg();dt=1//2^(4))
+array = collect(getiterator(sol))
+
+@test length(array) == 17
+@test fieldnames(array[1]) == [:timestamp, :value1, :value2]
+
+f_2dlinear_named = @ode_def LotkaVolterra begin
+    dx = 1.5*x - 1*x*y
+    dy = -3*y + 1*x*y
+end
+  
+prob = ODEProblem(f_2dlinear_named,[1.0,1.0],(0.0,1.0))
+sol =solve(prob,Tsit5())
+array = collect(getiterator(sol))
+
+@test length(array) == 7
+@test fieldnames(array[1]) == [:timestamp, :x, :y]


### PR DESCRIPTION
This moves the iterable tables integration from IterableTables.jl into this repo here.

Tests don't pass right now, I think mainly because I don't understand DiffEqBase well enough and the way these problems are setup doesn't work anymore with the new DiffEqBase release. My hope is that @ChrisRackauckas can point out how to change these in negative time.

A bigger questions is probably whether these tests should depend on ParameterizedFunctions.jl or not. Right now the last test does. Not sure what the best choice is there.

The corresponding PR on the IterableTables.jl side is https://github.com/davidanthoff/IterableTables.jl/pull/72. Ideally we should tag new versions of both packages roughly at the same time with these two PRs merged.