### PR TITLE
Tweak and fix step!, add set_t!

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -229,7 +229,7 @@ export resize!,deleteat!,addat!,get_tmp_cache,full_cache,user_cache,u_cache,du_c
        terminate!,
        add_tstop!,add_saveat!,set_abstol!,
        set_reltol!,get_du,get_dt,get_proposed_dt,set_proposed_dt!,u_modified!,
-       savevalues!,reinit!, auto_dt_reset!, set_t!
+       savevalues!,reinit!, auto_dt_reset!, set_t!, set_u!
 
 export numargs, @def
 

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -229,7 +229,7 @@ export resize!,deleteat!,addat!,get_tmp_cache,full_cache,user_cache,u_cache,du_c
        terminate!,
        add_tstop!,add_saveat!,set_abstol!,
        set_reltol!,get_du,get_dt,get_proposed_dt,set_proposed_dt!,u_modified!,
-       savevalues!,reinit!, auto_dt_reset!
+       savevalues!,reinit!, auto_dt_reset!, set_t!
 
 export numargs, @def
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -44,6 +44,14 @@ Set current time point of the `integrator` to `t`.
 set_t!(integrator::DEIntegrator, t::Real) =
     error("set_t!: method has not been implemented for the integrator")
 
+"""
+    set_u!(integrator::DEIntegrator, u)
+
+Set current state of the `integrator` to `u`.
+"""
+set_u!(integrator::DEIntegrator, u) =
+    error("set_u!: method has not been implemented for the integrator")
+
 ### Addat isn't a real thing. Let's make it a real thing Gretchen
 
 function addat!(a::AbstractArray,idxs,val=zeros(length(idxs)))

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -3,7 +3,8 @@
 Perform one (successful) step on the integrator.
 
 Alternative, if a `dt` is given, then `step!` the integrator until
-there is a temporal difference `≥ dt` in `integ.t`.
+there is a temporal difference `≥ dt` in `integ.t`.  It returns the
+actual temporal difference advanced by the integrator.
 """
 function step!(d::DEIntegrator) error("Integrator stepping is not implemented") end
 resize!(i::DEIntegrator,ii::Int) = error("resize!: method has not been implemented for the integrator")
@@ -195,4 +196,5 @@ function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
     while integ.t < next_t
         step!(integ)
     end
+    return integ.t - t
 end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -200,3 +200,11 @@ function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
     end
     return integ.t - t
 end
+
+"""
+    set_t!(integrator::DEIntegrator, t::Real)
+
+Set current time point of the `integrator` to `t`.
+"""
+set_t!(integrator::DEIntegrator, t::Real) =
+    error("integrator: method has not been implemented for the integrator")

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1,10 +1,12 @@
 """
-    step!(integ::DEIntegrator [, dt])
+    step!(integ::DEIntegrator [, dt [, stop_at_tdt]])
 Perform one (successful) step on the integrator.
 
 Alternative, if a `dt` is given, then `step!` the integrator until
 there is a temporal difference `≥ dt` in `integ.t`.  It returns the
-actual temporal difference advanced by the integrator.
+actual temporal difference advanced by the integrator.  When `true` is
+passed to the optional third argument, the integrator advances exactly
+`dt`.
 """
 function step!(d::DEIntegrator) error("Integrator stepping is not implemented") end
 resize!(i::DEIntegrator,ii::Int) = error("resize!: method has not been implemented for the integrator")

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -36,6 +36,14 @@ reinit!(integrator::DEIntegrator,args...; kwargs...) =
        error("reinit!: method has not been implemented for the integrator")
 auto_dt_reset!(integrator::DEIntegrator) = error("auto_dt_reset!: method has not been implemented for the integrator")
 
+"""
+    set_t!(integrator::DEIntegrator, t::Real)
+
+Set current time point of the `integrator` to `t`.
+"""
+set_t!(integrator::DEIntegrator, t::Real) =
+    error("set_t!: method has not been implemented for the integrator")
+
 ### Addat isn't a real thing. Let's make it a real thing Gretchen
 
 function addat!(a::AbstractArray,idxs,val=zeros(length(idxs)))
@@ -192,6 +200,7 @@ intervals(integrator::DEIntegrator) = IntegratorIntervals(integrator)
 end
 
 function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
+    (dt * integ.tdir) < 0 && error("Cannot step backward.")
     t = integ.t
     next_t = t+dt
     stop_at_tdt && add_tstop!(integ,next_t)
@@ -200,11 +209,3 @@ function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
     end
     return integ.t - t
 end
-
-"""
-    set_t!(integrator::DEIntegrator, t::Real)
-
-Set current time point of the `integrator` to `t`.
-"""
-set_t!(integrator::DEIntegrator, t::Real) =
-    error("integrator: method has not been implemented for the integrator")

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -54,7 +54,7 @@ set_u!(integrator::DEIntegrator, u) =
 
 
 """
-    set_u!(integrator::DEIntegrator, u, t)
+    set_ut!(integrator::DEIntegrator, u, t)
 
 Set current state of the `integrator` to `u` and `t`
 """

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -52,6 +52,15 @@ Set current state of the `integrator` to `u`.
 set_u!(integrator::DEIntegrator, u) =
     error("set_u!: method has not been implemented for the integrator")
 
+
+"""
+    set_u!(integrator::DEIntegrator, u, t)
+
+Set current state of the `integrator` to `u` and `t`
+"""
+set_ut!(integrator::DEIntegrator, u, t) =
+    error("set_ut!: method has not been implemented for the integrator")
+
 ### Addat isn't a real thing. Let's make it a real thing Gretchen
 
 function addat!(a::AbstractArray,idxs,val=zeros(length(idxs)))

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -194,7 +194,7 @@ end
 function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
     t = integ.t
     next_t = t+dt
-    stop_at_tdt && add_tstop(integ,next_t)
+    stop_at_tdt && add_tstop!(integ,next_t)
     while integ.t < next_t
         step!(integ)
     end

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -1,0 +1,24 @@
+mutable struct DummyIntegrator <: DEIntegrator
+  t
+  dt
+  tstops
+
+  DummyIntegrator() = new(0,1,[])
+end
+
+function DiffEqBase.add_tstop!(integrator::DummyIntegrator,t)
+  integrator.dt * (t - integrator.t) < 0 && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
+  push!(integrator.tstops,t)
+end
+
+function DiffEqBase.step!(integrator::DummyIntegrator)
+  t_next = integrator.t + integrator.dt
+  if ! isempty(integrator.tstops) && integrator.tstops[1] < t_next
+    t_next = integrator.tstops[1]
+  end
+  integrator.t = t_next
+end
+
+integrator = DummyIntegrator()
+@test step!(integrator, 1.5) == 2
+@test step!(integrator, 1.5, true) == 1.5

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -1,13 +1,14 @@
 mutable struct DummyIntegrator <: DEIntegrator
   t
   dt
+  tdir
   tstops
 
-  DummyIntegrator() = new(0,1,[])
+  DummyIntegrator() = new(0,1,1,[])
 end
 
 function DiffEqBase.add_tstop!(integrator::DummyIntegrator,t)
-  integrator.dt * (t - integrator.t) < 0 && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
+  integrator.tdir * (t - integrator.t) < 0 && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
   push!(integrator.tstops,t)
 end
 
@@ -22,3 +23,4 @@ end
 integrator = DummyIntegrator()
 @test step!(integrator, 1.5) == 2
 @test step!(integrator, 1.5, true) == 1.5
+@test_throws ErrorException step!(integrator, -1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ tic()
 @time @testset "Remake tests" begin include("remake_tests.jl") end
 @time @testset "Affine differential equation operators" begin include("affine_operators_tests.jl") end
 @time @testset "TableTraits" begin include("tabletraits_tests.jl") end
+@time @testset "Integrator interface" begin include("integrator_tests.jl") end
 toc()


### PR DESCRIPTION
closes https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/253

This PR bundles some related changes:

* Tweak `step!(integrator, dt)` to return the actual advanced step.
* Add `set_t!(integrator, t)`
* A few tests for integrator interface.
* Fixed a typo/bug in `step!`
