### PR TITLE
Check sol.retcode in done

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -159,7 +159,7 @@ end
 end
 
 @inline function done(integrator::DEIntegrator, _)
-  if check_error!(integrator) != :Success
+  if ! (integrator.sol.retcode in (:Default, :Success))
     return true
   elseif isempty(integrator.opts.tstops)
     postamble!(integrator)


### PR DESCRIPTION
Once https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/319 and https://github.com/JuliaDiffEq/StochasticDiffEq.jl/pull/74 are merged, there is no need to call `check_error!` in `done` since it is already called in `step!` (via `next`).

If `check_error!` (or in particular `postamble!`) is idempotent then the old code should be OK.  If so, maybe it's better to not pull this PR for a while, until all DiffEq downstreams call `check_error!` in `step!`.