### PR TITLE
Check sol.retcode in step!(integrator, dt)

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -315,6 +315,7 @@ function step!(integ::DEIntegrator, dt::Real, stop_at_tdt = false)
     stop_at_tdt && add_tstop!(integ,next_t)
     while integ.t < next_t
         step!(integ)
+        integ.sol.retcode in (:Default, :Success) || break
     end
     return integ.t - t
 end

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -1,10 +1,15 @@
+mutable struct DummySolution
+  retcode
+end
+
 mutable struct DummyIntegrator <: DEIntegrator
   t
   dt
   tdir
   tstops
+  sol
 
-  DummyIntegrator() = new(0,1,1,[])
+  DummyIntegrator() = new(0,1,1,[],DummySolution(:Default))
 end
 
 function DiffEqBase.add_tstop!(integrator::DummyIntegrator,t)


### PR DESCRIPTION
In `step!(integrator, dt)`, `integrator.sol.retcode` has to be checked since otherwise it could enter into an infinite loop.

See: https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/319 and https://github.com/JuliaDiffEq/StochasticDiffEq.jl/pull/74