### PR TITLE
time choice iterator

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -222,7 +222,7 @@ export isinplace, noise_class
 
 export solve, solve!, init, step!
 
-export tuples, intervals
+export tuples, intervals, TimeChoiceIterator
 
 export resize!,deleteat!,addat!,get_tmp_cache,full_cache,user_cache,u_cache,du_cache,
        resize_non_user_cache!,deleteat_non_user_cache!,addat_non_user_cache!,


### PR DESCRIPTION
This implements https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/252 at the abstract level for all DiffEq integrators using `step!` and the generic `get_tmp_cache` interface. It uses one cache value and mutates, so it assumes the user knows to not save the pointer of `u`.

However, since DiffEqBase doesn't have a full integrator implementation a test can't reside here. A downstream test was created:

https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/320

which is:

```julia
using OrdinaryDiffEq, DiffEqProblemLibrary, RecursiveArrayTools
integrator = init(prob_ode_2Dlinear,Tsit5();dt=1//2^(4))
ts = linspace(0,1,11)
us = Matrix{Float64}[]
for (u,t) in TimeChoiceIterator(integrator,ts)
  push!(us,copy(u))
end
@test VectorOfArray(us) ≈ integrator.sol(ts)
```

@simonbyrne this is what you asked for in Pk/Pd.