### PR TITLE
Remove undefined exports

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -208,6 +208,7 @@ include("data_array.jl")
 include("internal_euler.jl")
 include("juno_rendering.jl")
 include("tabletraits.jl")
+include("alg_traits.jl")
 
 export NSODEFunction
 
@@ -216,9 +217,9 @@ struct ConvergenceSetup{P,C}
     convergence_axis::C
 end
 
-export DEParameters, Mesh, ExplicitRKTableau, ImplicitRKTableau
+export ExplicitRKTableau, ImplicitRKTableau
 
-export isinplace, noise_class
+export isinplace
 
 export solve, solve!, init, step!
 
@@ -235,13 +236,11 @@ export numargs, @def
 
 export recursivecopy!, copy_fields, copy_fields!
 
-export construct_correlated_noisefunc
-
-export HasJac, HastGrad, HasParamFuncs, HasParamDeriv, HasParamJac,
+export HasJac, HastGrad, HasParamDeriv, HasParamJac,
        HasInvJac,HasInvW, HasInvW_t, HasHes, HasInvHes, HasSyms
 
 export has_jac, has_invjac, has_invW, has_invW_t, has_hes, has_invhes,
-       has_tgrad, has_paramfuncs, has_paramderiv, has_paramjac,
+       has_tgrad, has_paramderiv, has_paramjac,
        has_syms, has_analytic
 
 export DiscreteProblem
@@ -254,17 +253,12 @@ export AbstractDynamicalODEProblem, DynamicalODEFunction,
        AbstractSplitODEProblem, SplitFunction, SplitODEProblem
 export AbstractSplitSDEProblem, SplitSDEProblem
 export RODEProblem, RODESolution, SDEProblem
-export SecondOrderSDEProblem
 export DAEProblem, DAESolution
-export ConstantLagDDEProblem, DDEProblem
+export DDEProblem
 
 export BVProblem, TwoPointBVProblem
 
 export remake
-
-export ParameterizedFunction, DAEParameterizedFunction,
-       DDEParameterizedFunction,
-       ProbParameterizedFunction, OutputParameterizedFunction
 
 export DiffEqFunction
 
@@ -279,11 +273,9 @@ export ContinuousCallback, DiscreteCallback, CallbackSet
 
 export initialize!
 
-export param_values, num_params, problem_new_parameters, set_param_values!
+export problem_new_parameters
 
-export white_noise_func_wrapper, white_noise_func_wrapper!
-
-export is_diagonal_noise, is_sparse_noise
+export is_diagonal_noise
 
 export LinSolveFactorize, DEFAULT_LINSOLVE
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -175,3 +175,18 @@ function remake(thing; kwargs...)
   end
   return constructor(; struct_as_dict(thing)..., kwargs...)
 end
+
+"""
+    undefined_exports(mod)
+
+List symbols `export`'ed but not actually defined.
+"""
+function undefined_exports(mod)
+  undefined = []
+  for name in names(mod)
+    if ! isdefined(mod, name)
+      push!(undefined, name)
+    end
+  end
+  return undefined
+end

--- a/test/export_tests.jl
+++ b/test/export_tests.jl
@@ -1,0 +1,4 @@
+using DiffEqBase
+using Base.Test
+
+@test DiffEqBase.undefined_exports(DiffEqBase) == []

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,5 @@ end
 @time @testset "Affine differential equation operators" begin include("affine_operators_tests.jl") end
 @time @testset "TableTraits" begin include("tabletraits_tests.jl") end
 @time @testset "Integrator interface" begin include("integrator_tests.jl") end
+@time @testset "Export tests" begin include("export_tests.jl") end
 toc()


### PR DESCRIPTION
Here is a way to fix UndefVarError quirks (see also https://github.com/JuliaDiffEq/diffeqpy/pull/24#issuecomment-384885291).  I was half unsure if it's just end up being a yet another nitpick but I found that `include("alg_traits.jl")` is missing while making this PR.  I'm not sure if it is intentionally removed.  But if the intention was to add `include("alg_traits.jl")`, I think it actually make sense to include such test, at least in `DiffEqBase`, to make sure that the interface functions are correctly exported.

If we are to apply this to other packages, each package "just" have to add a one-linear test. For example, for `OrdinaryDiffEq`:

```julia
@test DiffEqBase.undefined_exports(OrdinaryDiffEq) == []
```

Fixing a package (say `OrdinaryDiffEq`) is less cumbersome, e.g., if you use `sed`:

```sh
sed -E -i "$(julia -e 'using DiffEqBase, OrdinaryDiffEq; println("s/\\b(", join(DiffEqBase.undefined_exports(OrdinaryDiffEq), "|"), ")\\b(, *)?//g")')" src/**/*.jl
```

Then just do `git diff` to see what's removed and fix some syntax errors.