### PR TITLE
Add zcolors

### DIFF
--- a/src/solutions/monte_solutions.jl
+++ b/src/solutions/monte_solutions.jl
@@ -92,6 +92,7 @@ end
 ### Plot Recipes
 
 @recipe function f(sim::AbstractMonteCarloSolution;
+                   zcolors = typeof(sim.u)<:AbstractArray ? fill(nothing, length(sim.u)) : nothing,
                    idxs = typeof(sim.u)<:AbstractArray ? eachindex(sim.u) : 1)
   for i in idxs
     size(sim[i].u, 1) == 0 && continue
@@ -100,6 +101,7 @@ end
       xlims --> (-Inf,Inf)
       ylims --> (-Inf,Inf)
       zlims --> (-Inf,Inf)
+      zcolor --> zcolors[i]
       sim[i]
     end
   end


### PR DESCRIPTION
Add an option to pass a `zcolor` for each series of an `AbstractMonteCarloSolution`.