### PR TITLE
Update arguments style for `DiffEqFunction`

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -39,12 +39,12 @@ end
 
 struct NSODEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
-function NSODEFunction(f,t,u;kwargs...)
-  iip = typeof(f)<: Tuple ? isinplace(f[2],3) : isinplace(f,3)
-  NSODEFunction{iip}(f,t,u;kwargs...)
+function NSODEFunction(f,u,p,t;kwargs...)
+  iip = typeof(f)<: Tuple ? isinplace(f[2],4) : isinplace(f,4)
+  NSODEFunction{iip}(f,u,p,t;kwargs...)
 end
 
-function NSODEFunction{iip}(f,t,u;analytic=nothing,
+function NSODEFunction{iip}(f,u,p,t;analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
                  invjac=nothing,
@@ -52,11 +52,11 @@ function NSODEFunction{iip}(f,t,u;analytic=nothing,
                  invW_t=nothing,
                  paramjac = nothing) where iip
                  if iip
-                   _f = (t,u,du) -> (f(t,u,du);nothing)
-                   wrap_f = FunctionWrappers.FunctionWrapper{Void,Tuple{typeof(t),typeof(u),typeof(u)}}(_f)
+                   _f = (du,u,p,t) -> (f(du,u,p,t);nothing)
+                   wrap_f = FunctionWrappers.FunctionWrapper{Void,Tuple{typeof(u),typeof(u),typeof(p),typeof(t)}}(_f)
                  else
                    _f = f
-                   wrap_f = FunctionWrappers.FunctionWrapper{typeof(u),Tuple{typeof(t),typeof(u)}}(_f)
+                   wrap_f = FunctionWrappers.FunctionWrapper{typeof(u),Tuple{typeof(u),typeof(p),typeof(t)}}(_f)
                  end
                  DiffEqFunction{iip,typeof(wrap_f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(invjac),typeof(invW),typeof(invW_t),

--- a/test/diffeqfunction_tests.jl
+++ b/test/diffeqfunction_tests.jl
@@ -1,10 +1,16 @@
-using DiffEqBase
+using DiffEqBase, Base.Test
 
-f(t,u,du) = (du.=u)
-DE_f = DiffEqFunction{true}(f)
-t = 0.0; u = Float64[1,2,3]; du = zeros(3)
-DE_f(t,u,du)
+f = (u,p,t) -> u
+f_ip = (du,u,p,t) -> du .= u
+DE_f = DiffEqFunction{false}(f)
+DE_f_ip = DiffEqFunction{true}(f_ip)
+du = zeros(3); u = [1.0,2.0,3.0]; p = nothing; t = 0.0
+@test DE_f(u,p,t) == u
+DE_f_ip(du,u,p,t)
+@test du == u
 
-NS_f = NSODEFunction(f,t,u)
-NS_f = NSODEFunction{true}(f,t,u)
-NS_f(t,u,du)
+NS_f = NSODEFunction(f,u,p,t)
+NS_f_ip = NSODEFunction(f_ip,u,p,t)
+@test NS_f(u,p,t) == u
+NS_f_ip(du,u,p,t)
+@test du == u


### PR DESCRIPTION
Updates the argument style from the old `(t,u[,du])` to `([du],u,p,t)`.

The section for `NSODEFunction` still seems problematic for me. First of all why create a dummy type `NSODEFunction` when in fact we're just returning a `DiffEqFunction`? The types for `FunctionWrapper` also don't take into account units (the type of `du` might be different from `u`).

Is it really necessary to use `FunctionWrapper` after all?