### PR TITLE
Better in-place detection for `DiffEqFunction`

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -34,6 +34,7 @@ function DiffEqFunction{iip}(f;analytic=nothing,
                  typeof(paramjac)}(f,analytic,tgrad,jac,invjac,invW,invW_t,
                  paramjac)
 end
+DiffEqFunction(f; kwargs...) = DiffEqFunction{isinplace(f, 4)}(f; kwargs...)
 
 ######### No Specialization Constructors
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,6 +30,8 @@ function isinplace(f::AbstractParameterizedFunction{iip},inplace_param_number) w
   iip
 end
 
+isinplace(f::AbstractDiffEqFunction{iip}, inplace_param_number) where {iip} = iip
+
 macro def(name, definition)
     return quote
         macro $(esc(name))()


### PR DESCRIPTION
Previously we need to explicitly specify `iip` both when constructing a `DiffEqFunction` and when creating an `ODEProblem` from a `DiffEqFunction` (if `f` is an in-place `DiffEqFunction` and `prob = ODEProblem(f, u0, tspan)`, then `prob` will be incorrectly classified as out-of-place. This update should fix the problem.

```julia
_f = (u,p,t) -> u
_fip = (du,u,p,t) -> du .= u
f = DiffEqFunction(_f)
fip = DiffEqFunction(_fip);
```


```julia
isinplace(f, 4)
```




    false




```julia
isinplace(fip, 4)
```




    true




```julia
prob = ODEProblem(f, rand(2), (0.0, 1.0))
```




    DiffEqBase.ODEProblem with uType Array{Float64,1} and tType Float64. In-place: false
    timespan: (0.0, 1.0)
    u0: [0.710152, 0.0412191]




```julia
prob = ODEProblem(fip, rand(2), (0.0, 1.0))
```




    DiffEqBase.ODEProblem with uType Array{Float64,1} and tType Float64. In-place: true
    timespan: (0.0, 1.0)
    u0: [0.814048, 0.951568]