### PR TITLE
0.7 compatibility

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -15,7 +15,9 @@ import RecursiveArrayTools: recursivecopy!, tuples
 
 import RecursiveArrayTools: chain
 
-import LinearAlgebra: exp, A_ldiv_B!
+import LinearAlgebra: exp, ldiv!
+
+import Statistics: mean
 
 # Problems
 abstract type DEProblem end

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -193,7 +193,7 @@ export remake
 
 export DEDataArray, DEDataVector, DEDataMatrix
 
-export ODEFunction
+export ODEFunction, DiscreteFunction
 
 export ContinuousCallback, DiscreteCallback, CallbackSet
 

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -73,6 +73,6 @@ end
 
 ################# Overloads for stiff solvers ##################################
 
-LinearAlgebra.A_ldiv_B!(A::DEDataArray,F::Factorization, B::DEDataArray) = A_ldiv_B!(A.x,F,B.x)
-LinearAlgebra.A_ldiv_B!(F::Factorization, B::DEDataArray) = A_ldiv_B!(F, B.x)
-LinearAlgebra.A_ldiv_B!(F::Factorization,A::Base.ReshapedArray{T1,T2,T3,T4}) where {T1,T2,T3<:DEDataArray,T4} = A_ldiv_B!(F,vec(A.parent.x))
+LinearAlgebra.ldiv!(A::DEDataArray,F::Factorization, B::DEDataArray) = ldiv!(A.x,F,B.x)
+LinearAlgebra.ldiv!(F::Factorization, B::DEDataArray) = ldiv!(F, B.x)
+LinearAlgebra.ldiv!(F::Factorization,A::Base.ReshapedArray{T1,T2,T3,T4}) where {T1,T2,T3<:DEDataArray,T4} = ldiv!(F,vec(A.parent.x))

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -22,7 +22,7 @@ has_exp(L::AbstractDiffEqOperator) = false # v = exp(L, t)*u
 has_mul(L::AbstractDiffEqOperator) = true # du = L*u
 has_mul!(L::AbstractDiffEqOperator) = false # A_mul_B!(du, L, u)
 has_ldiv(L::AbstractDiffEqOperator) = false # du = L\u
-has_ldiv!(L::AbstractDiffEqOperator) = false # A_ldiv_B!(du, L, u)
+has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 
 ### AbstractDiffEqLinearOperator Interface
 

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra
+
 mutable struct LinSolveFactorize{F}
   factorization::F
   A
@@ -7,9 +9,9 @@ function (p::LinSolveFactorize)(x,A,b,update_matrix=false)
   if update_matrix
     p.A = p.factorization(A)
   end
-  A_ldiv_B!(x,p.A,b)
+  ldiv!(x,p.A,b)
 end
-DEFAULT_LINSOLVE = LinSolveFactorize(lufact!)
+DEFAULT_LINSOLVE = LinSolveFactorize(lu!)
 function (p::LinSolveFactorize)(::Type{Val{:init}},f,u0_prototype)
   LinSolveFactorize(p.factorization,nothing)
 end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -7,33 +7,38 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   tspan::tType
   p::P
   callback::C
-  @add_kwonly function DiscreteProblem{iip}(f,u0,tspan,p=nothing;
-           callback = nothing) where {iip}
+  @add_kwonly function DiscreteProblem(f::AbstractDiscreteFunction,
+                                            u0,tspan,p=nothing;
+                                            callback = nothing)
     _tspan = promote_tspan(tspan)
-    new{typeof(u0),typeof(_tspan),iip,
+    new{typeof(u0),typeof(_tspan),isinplace(f,4),
         typeof(p),
         typeof(f),typeof(callback)}(f,u0,_tspan,p,callback)
+  end
+
+  function DiscreteProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}
+    DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
   end
 end
 
 function DiscreteProblem(f,u0,tspan::Tuple,p::Tuple;kwargs...)
   iip = isinplace(f,4)
-  DiscreteProblem{iip}(f,u0,tspan,p;kwargs...)
+  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end
 
 function DiscreteProblem(f,u0,tspan::Tuple,p=nothing;kwargs...)
   iip = isinplace(f,4)
-  DiscreteProblem{iip}(f,u0,tspan,p;kwargs...)
+  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end
 
 function DiscreteProblem(u0,tspan::Tuple,p::Tuple;kwargs...)
-    iip = typeof(u0) <: AbstractArray
-    if iip
-      f = DISCRETE_INPLACE_DEFAULT
-    else
-      f = DISCRETE_OUTOFPLACE_DEFAULT
-    end
-    DiscreteProblem{iip}(f,u0,tspan,p;kwargs...)
+  iip = typeof(u0) <: AbstractArray
+  if iip
+    f = DISCRETE_INPLACE_DEFAULT
+  else
+    f = DISCRETE_OUTOFPLACE_DEFAULT
+  end
+  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end
 
 function DiscreteProblem(u0,tspan::Tuple,p=nothing;kwargs...)
@@ -43,5 +48,5 @@ function DiscreteProblem(u0,tspan::Tuple,p=nothing;kwargs...)
   else
     f = DISCRETE_OUTOFPLACE_DEFAULT
   end
-  DiscreteProblem{iip}(f,u0,tspan,p;kwargs...)
+  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -1,5 +1,5 @@
-const DISCRETE_INPLACE_DEFAULT = (du,u,p,t) -> du.=u
-const DISCRETE_OUTOFPLACE_DEFAULT = (u,p,t) -> u
+const DISCRETE_INPLACE_DEFAULT = convert(DiscreteFunction{true},(du,u,p,t) -> du.=u)
+const DISCRETE_OUTOFPLACE_DEFAULT = convert(DiscreteFunction{false},(u,p,t) -> u)
 
 struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
   f::F
@@ -8,7 +8,7 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   p::P
   callback::C
   @add_kwonly function DiscreteProblem(f::AbstractDiscreteFunction,
-                                            u0,tspan::Tuple,p=nothing;
+                                            u0,tspan,p=nothing;
                                             callback = nothing)
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),isinplace(f,4),
@@ -38,7 +38,7 @@ function DiscreteProblem(u0,tspan::Tuple,p::Tuple;kwargs...)
   else
     f = DISCRETE_OUTOFPLACE_DEFAULT
   end
-  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
+  DiscreteProblem(f,u0,tspan,p;kwargs...)
 end
 
 function DiscreteProblem(u0,tspan::Tuple,p=nothing;kwargs...)
@@ -48,5 +48,5 @@ function DiscreteProblem(u0,tspan::Tuple,p=nothing;kwargs...)
   else
     f = DISCRETE_OUTOFPLACE_DEFAULT
   end
-  DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
+  DiscreteProblem(f,u0,tspan,p;kwargs...)
 end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -8,7 +8,7 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   p::P
   callback::C
   @add_kwonly function DiscreteProblem(f::AbstractDiscreteFunction,
-                                            u0,tspan,p=nothing;
+                                            u0,tspan::Tuple,p=nothing;
                                             callback = nothing)
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),isinplace(f,4),

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -8,7 +8,7 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   p::P
   callback::C
   @add_kwonly function DiscreteProblem(f::AbstractDiscreteFunction,
-                                            u0,tspan,p=nothing;
+                                            u0,tspan::Tuple,p=nothing;
                                             callback = nothing)
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),isinplace(f,4),
@@ -21,7 +21,7 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   end
 end
 
-function DiscreteProblem(f,u0,tspan::Tuple,p::Tuple;kwargs...)
+function DiscreteProblem(f,u0,tspan::Tuple,p;kwargs...)
   iip = isinplace(f,4)
   DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -37,7 +37,7 @@ function build_solution(
     f = prob.f
   end
 
-  if !(typeof(prob)<:DiscreteProblem) && has_analytic(f)
+  if has_analytic(f)
     if !(typeof(prob.u0) <: Tuple)
       u_analytic = Vector{typeof(prob.u0)}()
       errors = Dict{Symbol,real(eltype(prob.u0))}()

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -37,7 +37,7 @@ function build_solution(
     f = prob.f
   end
 
-  if has_analytic(f)
+  if !(typeof(prob)<:DiscreteProblem) && has_analytic(f)
     if !(typeof(prob.u0) <: Tuple)
       u_analytic = Vector{typeof(prob.u0)}()
       errors = Dict{Symbol,real(eltype(prob.u0))}()

--- a/test/diffeqfunction_tests.jl
+++ b/test/diffeqfunction_tests.jl
@@ -4,13 +4,19 @@ f_op = (u,p,t) -> u
 f_ip = (du,u,p,t) -> du .= u
 DE_f = ODEFunction{false}(f_op)
 DE_f_ip = ODEFunction{true}(f_ip)
+DI_f = DiscreteFunction{false}(f_op)
+DI_f_ip = DiscreteFunction{true}(f_ip)
 du = zeros(3); u = [1.0,2.0,3.0]; p = nothing; t = 0.0
 @test DE_f(u,p,t) == u
 DE_f_ip(du,u,p,t)
+@test du == u
+@test DI_f(u,p,t) == u
+DI_f_ip(du,u,p,t)
 @test du == u
 
 f(u,p,t) = u
 jac = (u,p,t) -> 1
 @inferred ODEFunction{false}(f_op,jac=jac)
+@inferred DiscreteFunction{false}(f_op,analytic=f)
 
 f(du,u,p,t) = u

--- a/test/problem_creation_tests.jl
+++ b/test/problem_creation_tests.jl
@@ -21,7 +21,7 @@ prob = ODEProblem{false}(f,u0,tspan)
 @test_broken @inferred ODEProblem(f,u0,tspan)
 
 function f(dv,u,v,p,t)
-  dv .= 2.*v
+  dv .= 2.0 .* v
 end
 u0 = ones(2)
 v0 = ones(2)


### PR DESCRIPTION
This PR aims to fix a test failure in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/392, i.e.

```julia
  prob = DiscreteProblem(0.5,(0.0,1.0))
  sol = solve(prob,FunctionMap())
```

It also fixs some depwarns by `LinearAlgebra` and `Statistics`.