### PR TITLE
Update handling of `jac_prototype`

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -1,11 +1,12 @@
 const RECOMPILE_BY_DEFAULT = true
 
 abstract type AbstractODEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct ODEFunction{iip,F,Ta,Tt,TJ,TW,TWt,TPJ,S} <: AbstractODEFunction{iip}
+struct ODEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{iip}
   f::F
   analytic::Ta
   tgrad::Tt
   jac::TJ
+  jac_prototype::JP
   invW::TW
   invW_t::TWt
   paramjac::TPJ
@@ -26,11 +27,12 @@ struct DynamicalODEFunction{iip,F1,F2,Ta} <: AbstractODEFunction{iip}
 end
 
 abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct DDEFunction{iip,F,Ta,Tt,TJ,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
+struct DDEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
   f::F
   analytic::Ta
   tgrad::Tt
   jac::TJ
+  jac_prototype::JP
   invW::TW
   invW_t::TWt
   paramjac::TPJ
@@ -44,12 +46,13 @@ struct DiscreteFunction{iip,F,Ta} <: AbstractDiscreteFunction{iip}
 end
 
 abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct SDEFunction{iip,F,G,Ta,Tt,TJ,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
+struct SDEFunction{iip,F,G,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
   f::F
   g::G
   analytic::Ta
   tgrad::Tt
   jac::TJ
+  jac_prototype::JP
   invW::TW
   invW_t::TWt
   paramjac::TPJ
@@ -58,11 +61,12 @@ struct SDEFunction{iip,F,G,Ta,Tt,TJ,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
 end
 
 abstract type AbstractRODEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct RODEFunction{iip,F,Ta,Tt,TJ,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
+struct RODEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
   f::F
   analytic::Ta
   tgrad::Tt
   jac::TJ
+  jac_prototype::JP
   invW::TW
   invW_t::TWt
   paramjac::TPJ
@@ -70,11 +74,12 @@ struct RODEFunction{iip,F,Ta,Tt,TJ,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
 end
 
 abstract type AbstractDAEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct DAEFunction{iip,F,Ta,Tt,TJ,TW,TWt,TPJ,S} <: AbstractDAEFunction{iip}
+struct DAEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDAEFunction{iip}
   f::F
   analytic::Ta
   tgrad::Tt
   jac::TJ
+  jac_prototype::JP
   invW::TW
   invW_t::TWt
   paramjac::TPJ
@@ -137,28 +142,30 @@ function ODEFunction{iip,true}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  ODEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
-                 typeof(jac),typeof(invW),typeof(invW_t),
+                 typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 function ODEFunction{iip,false}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  ODEFunction{iip,Any,Any,Any,
-                 Any,Any,Any,
+                 Any,Any,Any,Any,
                  Any,typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 ODEFunction(f; kwargs...) = ODEFunction{isinplace(f, 4),RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -208,6 +215,7 @@ function SDEFunction{iip,true}(f,g;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
@@ -215,25 +223,26 @@ function SDEFunction{iip,true}(f,g;
                  syms = nothing) where iip
                  SDEFunction{iip,typeof(f),typeof(g),
                  typeof(analytic),typeof(tgrad),
-                 typeof(jac),typeof(invW),typeof(invW_t),
+                 typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms),
                  typeof(ggprime)}(
-                 f,g,analytic,tgrad,jac,invW,invW_t,
+                 f,g,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,ggprime,syms)
 end
 function SDEFunction{iip,false}(f,g;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  ggprime = nothing,
                  syms = nothing) where iip
                  SDEFunction{iip,Any,Any,Any,Any,
-                 Any,Any,Any,
+                 Any,Any,Any,Any,
                  Any,typeof(syms),Any}(
-                 f,g,analytic,tgrad,jac,invW,invW_t,
+                 f,g,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,ggprime,syms)
 end
 SDEFunction(f,g; kwargs...) = SDEFunction{isinplace(f, 4),RECOMPILE_BY_DEFAULT}(f,g; kwargs...)
@@ -242,15 +251,16 @@ function RODEFunction{iip,true}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  RODEFunction{iip,typeof(f),
                  typeof(analytic),typeof(tgrad),
-                 typeof(jac),typeof(invW),typeof(invW_t),
+                 typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 function RODEFunction{iip,false}(f;
@@ -262,9 +272,9 @@ function RODEFunction{iip,false}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  RODEFunction{iip,Any,Any,Any,
-                 Any,Any,Any,
+                 Any,Any,Any,Any,
                  Any,typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 RODEFunction(f; kwargs...) = RODEFunction{isinplace(f, 5),RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -273,28 +283,30 @@ function DAEFunction{iip,true}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  DAEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
-                 typeof(jac),typeof(invW),typeof(invW_t),
+                 typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 function DAEFunction{iip,false}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  DAEFunction{iip,Any,Any,Any,
-                 Any,Any,Any,
+                 Any,Any,Any,Any,
                  Any,typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 DAEFunction(f; kwargs...) = DAEFunction{isinplace(f, 5),RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -303,28 +315,30 @@ function DDEFunction{iip,true}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  DDEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
-                 typeof(jac),typeof(invW),typeof(invW_t),
+                 typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 function DDEFunction{iip,false}(f;
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
+                 jac_prototype=nothing,
                  invW=nothing,
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
                  DDEFunction{iip,Any,Any,Any,
-                 Any,Any,Any,
+                 Any,Any,Any,Any,
                  Any,typeof(syms)}(
-                 f,analytic,tgrad,jac,invW,invW_t,
+                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 DDEFunction(f; kwargs...) = DDEFunction{isinplace(f, 5),RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -392,7 +406,7 @@ function Base.convert(::Type{ODEFunction},f)
   else
     syms = nothing
   end
-  ODEFunction(f,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  ODEFunction(f;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 function Base.convert(::Type{ODEFunction{iip}},f) where iip
@@ -432,7 +446,7 @@ function Base.convert(::Type{ODEFunction{iip}},f) where iip
   else
     syms = nothing
   end
-  ODEFunction{iip,RECOMPILE_BY_DEFAULT}(f,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  ODEFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 
@@ -443,7 +457,7 @@ function Base.convert(::Type{DiscreteFunction},f)
   else
     analytic = nothing
   end
-  DiscreteFunction(f,analytic=analytic)
+  DiscreteFunction(f;analytic=analytic)
 end
 function Base.convert(::Type{DiscreteFunction{iip}},f) where iip
   if __has_analytic(f)
@@ -451,7 +465,7 @@ function Base.convert(::Type{DiscreteFunction{iip}},f) where iip
   else
     analytic = nothing
   end
-  DiscreteFunction{iip,RECOMPILE_BY_DEFAULT}(f,analytic=analytic)
+  DiscreteFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic)
 end
 
 DAEFunction{iip}(f::T) where {iip,T} = return T<:DAEFunction ? f : convert(DAEFunction{iip},f)
@@ -492,7 +506,7 @@ function Base.convert(::Type{DAEFunction},f)
   else
     syms = nothing
   end
-  DAEFunction(f,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  DAEFunction(f;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 function Base.convert(::Type{DAEFunction{iip}},f) where iip
@@ -532,7 +546,7 @@ function Base.convert(::Type{DAEFunction{iip}},f) where iip
   else
     syms = nothing
   end
-  DAEFunction{iip,RECOMPILE_BY_DEFAULT}(f,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  DAEFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 
@@ -548,7 +562,7 @@ function Base.convert(::Type{DDEFunction},f)
   else
     syms = nothing
   end
-  DDEFunction(f,analytic=analytic,syms=syms)
+  DDEFunction(f;analytic=analytic,syms=syms)
 end
 function Base.convert(::Type{DDEFunction{iip}},f) where iip
   if __has_analytic(f)
@@ -561,7 +575,7 @@ function Base.convert(::Type{DDEFunction{iip}},f) where iip
   else
     syms = nothing
   end
-  DDEFunction{iip,RECOMPILE_BY_DEFAULT}(f,analytic=analytic,syms=syms)
+  DDEFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic,syms=syms)
 end
 
 SDEFunction{iip}(f::T,g::T2) where {iip,T,T2} = return T<:SDEFunction ? f : convert(SDEFunction{iip},f,g)
@@ -602,7 +616,7 @@ function Base.convert(::Type{SDEFunction},f,g)
   else
     syms = nothing
   end
-  SDEFunction(f,g,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  SDEFunction(f,g;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 function Base.convert(::Type{SDEFunction{iip}},f,g) where iip
@@ -642,7 +656,7 @@ function Base.convert(::Type{SDEFunction{iip}},f,g) where iip
   else
     syms = nothing
   end
-  SDEFunction{iip,RECOMPILE_BY_DEFAULT}(f,g,analytic=analytic,
+  SDEFunction{iip,RECOMPILE_BY_DEFAULT}(f,g;analytic=analytic,
               tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
@@ -685,7 +699,7 @@ function Base.convert(::Type{RODEFunction},f)
   else
     syms = nothing
   end
-  RODEFunction(f,analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
+  RODEFunction(f;analytic=analytic,tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end
 function Base.convert(::Type{RODEFunction{iip}},f) where iip
@@ -725,7 +739,7 @@ function Base.convert(::Type{RODEFunction{iip}},f) where iip
   else
     syms = nothing
   end
-  RODEFunction{iip,RECOMPILE_BY_DEFAULT}(f,analytic=analytic,
+  RODEFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic,
               tgrad=tgrad,jac=jac,invW=invW,
               invW_t=invW_t,paramjac=paramjac,syms=syms)
 end

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -228,7 +228,11 @@ function SDEFunction{iip,true}(f,g;
                  ggprime = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  SDEFunction{iip,typeof(f),typeof(g),
                  typeof(analytic),typeof(tgrad),
@@ -249,7 +253,11 @@ function SDEFunction{iip,false}(f,g;
                  ggprime = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  SDEFunction{iip,Any,Any,Any,Any,
                  Any,Any,Any,Any,
@@ -269,7 +277,11 @@ function RODEFunction{iip,true}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  RODEFunction{iip,typeof(f),
                  typeof(analytic),typeof(tgrad),
@@ -287,7 +299,11 @@ function RODEFunction{iip,false}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  RODEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
@@ -307,7 +323,11 @@ function DAEFunction{iip,true}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  DAEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
@@ -325,7 +345,11 @@ function DAEFunction{iip,false}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  DAEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
@@ -345,7 +369,11 @@ function DDEFunction{iip,true}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  DDEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
@@ -363,7 +391,11 @@ function DDEFunction{iip,false}(f;
                  paramjac = nothing,
                  syms = nothing) where iip
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
-                   jac = update_coefficients!
+                  if iip
+                    jac = update_coefficients! #(J,u,p,t)
+                  else
+                    jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
+                  end
                  end
                  DDEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -147,6 +147,9 @@ function ODEFunction{iip,true}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  ODEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
@@ -162,6 +165,9 @@ function ODEFunction{iip,false}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  ODEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms)}(
@@ -221,6 +227,9 @@ function SDEFunction{iip,true}(f,g;
                  paramjac = nothing,
                  ggprime = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  SDEFunction{iip,typeof(f),typeof(g),
                  typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
@@ -239,6 +248,9 @@ function SDEFunction{iip,false}(f,g;
                  paramjac = nothing,
                  ggprime = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  SDEFunction{iip,Any,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms),Any}(
@@ -256,6 +268,9 @@ function RODEFunction{iip,true}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  RODEFunction{iip,typeof(f),
                  typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
@@ -271,6 +286,9 @@ function RODEFunction{iip,false}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  RODEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms)}(
@@ -288,6 +306,9 @@ function DAEFunction{iip,true}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  DAEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
@@ -303,6 +324,9 @@ function DAEFunction{iip,false}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  DAEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms)}(
@@ -320,6 +344,9 @@ function DDEFunction{iip,true}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  DDEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
@@ -335,6 +362,9 @@ function DDEFunction{iip,false}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
+                 if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
+                   jac = update_coefficients!
+                 end
                  DDEFunction{iip,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms)}(

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -1,24 +1,22 @@
 struct StandardBVProblem end
 
-struct BVProblem{uType,tType,isinplace,P,J,F,bF,PT,CB,MM} <: AbstractBVProblem{uType,tType,isinplace}
+struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB,MM} <: AbstractBVProblem{uType,tType,isinplace}
     f::F
     bc::bF
     u0::uType
     tspan::tType
     p::P
-    jac_prototype::J
     problem_type::PT
     callback::CB
     mass_matrix::MM
     @add_kwonly function BVProblem{iip}(f,bc,u0,tspan,p=nothing,
                             problem_type=StandardBVProblem();
-                            jac_prototype = nothing,
                             callback=nothing,mass_matrix=I) where {iip}
         _tspan = promote_tspan(tspan)
-        new{typeof(u0),typeof(tspan),iip,typeof(p),typeof(jac_prototype),
+        new{typeof(u0),typeof(tspan),iip,typeof(p),
                   typeof(f),typeof(bc),
                   typeof(problem_type),typeof(callback),typeof(mass_matrix)}(
-                  f,bc,u0,_tspan,p,jac_prototype,
+                  f,bc,u0,_tspan,p,
                   problem_type,callback,mass_matrix)
     end
 end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -1,23 +1,21 @@
 # f(t,u,du,res) = 0
-struct DAEProblem{uType,duType,tType,isinplace,P,J,F,C,D} <: AbstractDAEProblem{uType,duType,tType,isinplace}
+struct DAEProblem{uType,duType,tType,isinplace,P,F,C,D} <: AbstractDAEProblem{uType,duType,tType,isinplace}
   f::F
   du0::duType
   u0::uType
   tspan::tType
   p::P
-  jac_prototype::J
   callback::C
   differential_vars::D
   @add_kwonly function DAEProblem(f::AbstractDAEFunction,du0,u0,tspan,p=nothing;
-                      jac_prototype = nothing,
                       callback = nothing,
                       differential_vars = nothing)
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(du0),typeof(_tspan),
-               isinplace(f),typeof(p),typeof(jac_prototype),
+               isinplace(f),typeof(p),
                typeof(f),typeof(callback),
                typeof(differential_vars)}(
-               f,du0,u0,_tspan,p,jac_prototype,
+               f,du0,u0,_tspan,p,
                callback,differential_vars)
   end
 

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -1,11 +1,10 @@
-struct DDEProblem{uType,tType,lType,lType2,isinplace,P,J,F,H,C,MM} <:
+struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C,MM} <:
                           AbstractDDEProblem{uType,tType,lType,isinplace}
   f::F
   u0::uType
   h::H
   tspan::tType
   p::P
-  jac_prototype::J
   constant_lags::lType
   dependent_lags::lType2
   callback::C
@@ -13,7 +12,6 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,J,F,H,C,MM} <:
   neutral::Bool
   @add_kwonly function DDEProblem(f::AbstractDDEFunction,
                                  u0,h,tspan,p=nothing;
-                                 jac_prototype = nothing,
                                  constant_lags=[],
                                  dependent_lags=[],
                                  mass_matrix=I,
@@ -23,10 +21,9 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,J,F,H,C,MM} <:
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),
                typeof(constant_lags),typeof(dependent_lags),
-               isinplace(f),typeof(p),typeof(jac_prototype),
+               isinplace(f),typeof(p),
                typeof(f),typeof(h),typeof(callback),
                typeof(mass_matrix)}(f,u0,h,_tspan,p,
-                                    jac_prototype,
                                     constant_lags,
                                     dependent_lags,callback,
                                     mass_matrix,neutral)

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -1,19 +1,17 @@
 struct StandardODEProblem end
 
 # Mu' = f
-struct ODEProblem{uType,tType,isinplace,P,F,J,C,MM,PT} <:
+struct ODEProblem{uType,tType,isinplace,P,F,C,MM,PT} <:
                AbstractODEProblem{uType,tType,isinplace}
   f::F
   u0::uType
   tspan::tType
   p::P
-  jac_prototype::J
   callback::C
   mass_matrix::MM
   problem_type::PT
   @add_kwonly function ODEProblem(f::AbstractODEFunction,u0,tspan,p=nothing,
                       problem_type=StandardODEProblem();
-                      jac_prototype = nothing,
                       callback=nothing,mass_matrix=I)
     _tspan = promote_tspan(tspan)
     if mass_matrix == I && typeof(f) <: Tuple
@@ -22,10 +20,10 @@ struct ODEProblem{uType,tType,isinplace,P,F,J,C,MM,PT} <:
       _mm = mass_matrix
     end
     new{typeof(u0),typeof(_tspan),
-       isinplace(f),typeof(p),typeof(f),typeof(jac_prototype),
+       isinplace(f),typeof(p),typeof(f),
        typeof(callback),typeof(_mm),
        typeof(problem_type)}(
-       f,u0,_tspan,p,jac_prototype,callback,_mm,problem_type)
+       f,u0,_tspan,p,callback,_mm,problem_type)
   end
 
   function ODEProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,25 +1,23 @@
-mutable struct RODEProblem{uType,tType,isinplace,P,J,NP,F,C,MM,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
+mutable struct RODEProblem{uType,tType,isinplace,P,NP,F,C,MM,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
   f::F
   u0::uType
   tspan::tType
   p::P
-  jac_prototype::J
   noise::NP
   callback::C
   mass_matrix::MM
   rand_prototype::ND
   seed::UInt64
   @add_kwonly function RODEProblem(f::RODEFunction,u0,tspan,p=nothing;
-                       jac_prototype = nothing,
                        rand_prototype = nothing,
                        noise= nothing, seed = UInt64(0),
                        callback=nothing,mass_matrix=I)
   _tspan = promote_tspan(tspan)
   new{typeof(u0),typeof(_tspan),
-              isinplace(f),typeof(p),typeof(jac_prototype),
+              isinplace(f),typeof(p),
               typeof(noise),typeof(f),typeof(callback),
               typeof(mass_matrix),typeof(rand_prototype)}(
-              f,u0,_tspan,p,jac_prototype,noise,callback,
+              f,u0,_tspan,p,noise,callback,
               mass_matrix,rand_prototype,seed)
   end
   function RODEProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -1,12 +1,11 @@
 struct StandardSDEProblem end
 
-struct SDEProblem{uType,tType,isinplace,P,J,NP,F,G,C,MM,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
+struct SDEProblem{uType,tType,isinplace,P,NP,F,G,C,MM,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
   f::F
   g::G
   u0::uType
   tspan::tType
   p::P
-  jac_prototype::J
   noise::NP
   callback::C
   mass_matrix::MM
@@ -14,7 +13,6 @@ struct SDEProblem{uType,tType,isinplace,P,J,NP,F,G,C,MM,ND} <: AbstractSDEProble
   seed::UInt64
   @add_kwonly function SDEProblem(f::AbstractSDEFunction,g,u0,
           tspan,p=nothing,problem_type=StandardSDEProblem();
-          jac_prototype = nothing,
           noise_rate_prototype = nothing,
           noise= nothing, seed = UInt64(0),
           callback = nothing,mass_matrix=I)
@@ -26,11 +24,11 @@ struct SDEProblem{uType,tType,isinplace,P,J,NP,F,G,C,MM,ND} <: AbstractSDEProble
     end
 
     new{typeof(u0),typeof(_tspan),
-        isinplace(f),typeof(p),typeof(jac_prototype),
+        isinplace(f),typeof(p),
         typeof(noise),typeof(f),typeof(f.g),
         typeof(callback),typeof(_mm),
         typeof(noise_rate_prototype)}(
-        f,f.g,u0,_tspan,p,jac_prototype,
+        f,f.g,u0,_tspan,p,
         noise,callback,_mm,
         noise_rate_prototype,seed)
   end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,15 +1,13 @@
 # Mu' = f
-struct SteadyStateProblem{uType,isinplace,P,J,F,MM} <: AbstractSteadyStateProblem{uType,isinplace}
+struct SteadyStateProblem{uType,isinplace,P,F,MM} <: AbstractSteadyStateProblem{uType,isinplace}
   f::F
   u0::uType
   p::P
-  jac_prototype::J
   mass_matrix::MM
   @add_kwonly function SteadyStateProblem{iip}(f,u0,p=nothing;
-                                   jac_prototype=nothing,
                                    mass_matrix=I) where iip
-    new{typeof(u0),iip,typeof(p),typeof(jac_prototype),
-        typeof(f),typeof(mass_matrix)}(f,u0,p,jac_prototype,mass_matrix)
+    new{typeof(u0),iip,typeof(p),
+        typeof(f),typeof(mass_matrix)}(f,u0,p,mass_matrix)
   end
 end
 

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -32,7 +32,6 @@ prob2 = remake(prob1; u0 = prob1.u0 .+ 1)
 @test prob1.p === prob2.p
 @test prob1.u0 .+ 1 ≈ prob2.u0
 @test prob1.tspan == prob2.tspan
-@test prob1.jac_prototype === prob2.jac_prototype
 @test prob1.callback === prob2.callback
 @test prob1.mass_matrix === prob2.mass_matrix
 @test prob1.problem_type === prob2.problem_type


### PR DESCRIPTION
To address https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/416#issuecomment-405622364, the `jac_prototype` field is moved from `*DEProblem` to `*DEFunction`. In addition, `f.jac` is automatically set to use `update_coefficients!` if the constructor is given a `AbstractDiffEqLinearOperator` and no custom jacobian update function is given (for out-of-place `f`, first a copy is made from `jac_prototype` and then `update_coefficients!` is called on the copy).