### PR TITLE
Mass matrix change

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -22,9 +22,10 @@ struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
   analytic::Ta
 end
 
-struct DynamicalODEFunction{iip,F1,F2,Ta} <: AbstractODEFunction{iip}
+struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
   f1::F1
   f2::F2
+  mass_matrix::TMM
   analytic::Ta
 end
 
@@ -211,15 +212,15 @@ SplitFunction{iip,RECOMPILE_BY_DEFAULT}(
 typeof(f1) <: AbstractDiffEqOperator ? f1 : ODEFunction(f1),
 ODEFunction{iip}(f2); kwargs...)
 
-@add_kwonly function DynamicalODEFunction{iip}(f1,f2,analytic) where iip
+@add_kwonly function DynamicalODEFunction{iip}(f1,f2,mass_matrix,analytic) where iip
   f1 = ODEFunction(f1)
   f2 != nothing && (f2 = ODEFunction(f2))
-  DynamicalODEFunction{iip,typeof(f1),typeof(f2),typeof(analytic)}(f1,f2,analytic)
+  DynamicalODEFunction{iip,typeof(f1),typeof(f2),typeof(mass_matrix),typeof(analytic)}(f1,f2,mass_matrix,analytic)
 end
-DynamicalODEFunction{iip,true}(f1,f2;analytic=nothing) where iip =
-DynamicalODEFunction{iip,typeof(f1),typeof(f2),typeof(analytic)}(f1,f2,analytic)
-DynamicalODEFunction{iip,false}(f1,f2;analytic=nothing) where iip =
-DynamicalODEFunction{iip,Any,Any,Any}(f1,f2,analytic)
+DynamicalODEFunction{iip,true}(f1,f2;mass_matrix=(I,I),analytic=nothing) where iip =
+DynamicalODEFunction{iip,typeof(f1),typeof(f2),typeof(mass_matrix),typeof(analytic)}(f1,f2,mass_matrix,analytic)
+DynamicalODEFunction{iip,false}(f1,f2;mass_matrix=(I,I),analytic=nothing) where iip =
+DynamicalODEFunction{iip,Any,Any,Any,Any}(f1,f2,mass_matrix,analytic)
 DynamicalODEFunction(f1,f2=nothing; kwargs...) = DynamicalODEFunction{isinplace(f1, 5)}(f1, f2; kwargs...)
 DynamicalODEFunction{iip}(f1,f2; kwargs...) where iip =
 DynamicalODEFunction{iip,RECOMPILE_BY_DEFAULT}(ODEFunction{iip}(f1), ODEFunction{iip}(f2); kwargs...)

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -30,8 +30,9 @@ struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
 end
 
 abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct DDEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
+struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
   f::F
+  mass_matrix::TMM
   analytic::Ta
   tgrad::Tt
   jac::TJ
@@ -380,6 +381,7 @@ end
 DAEFunction(f; kwargs...) = DAEFunction{isinplace(f, 5),RECOMPILE_BY_DEFAULT}(f; kwargs...)
 
 function DDEFunction{iip,true}(f;
+                 mass_matrix=I,
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
@@ -395,13 +397,14 @@ function DDEFunction{iip,true}(f;
                     jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
                   end
                  end
-                 DDEFunction{iip,typeof(f),typeof(analytic),typeof(tgrad),
+                 DDEFunction{iip,typeof(f),typeof(mass_matrix),typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(
-                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
+                 f,mass_matrix,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 function DDEFunction{iip,false}(f;
+                 mass_matrix=I,
                  analytic=nothing,
                  tgrad=nothing,
                  jac=nothing,
@@ -417,10 +420,10 @@ function DDEFunction{iip,false}(f;
                     jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
                   end
                  end
-                 DDEFunction{iip,Any,Any,Any,
+                 DDEFunction{iip,Any,Any,Any,Any,
                  Any,Any,Any,Any,
                  Any,typeof(syms)}(
-                 f,analytic,tgrad,jac,jac_prototype,invW,invW_t,
+                 f,mass_matrix,analytic,tgrad,jac,jac_prototype,invW,invW_t,
                  paramjac,syms)
 end
 DDEFunction(f; kwargs...) = DDEFunction{isinplace(f, 5),RECOMPILE_BY_DEFAULT}(f; kwargs...)

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -180,10 +180,6 @@ function ODEFunction{iip,false}(f;
                  invW_t=nothing,
                  paramjac = nothing,
                  syms = nothing) where iip
-                 # Is this still necessary?
-                 if mass_matrix == I && typeof(f) <: Tuple
-                  mass_matrix = ((I for i in 1:length(f))...,)
-                 end
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
                   if iip
                     jac = update_coefficients! #(J,u,p,t)
@@ -251,10 +247,6 @@ function SDEFunction{iip,true}(f,g;
                  paramjac = nothing,
                  ggprime = nothing,
                  syms = nothing) where iip
-                 # Is this still necessary?
-                 if mass_matrix == I && typeof(f) <: Tuple
-                  mass_matrix = ((I for i in 1:length(f))...,)
-                 end
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
                   if iip
                     jac = update_coefficients! #(J,u,p,t)
@@ -281,10 +273,6 @@ function SDEFunction{iip,false}(f,g;
                  paramjac = nothing,
                  ggprime = nothing,
                  syms = nothing) where iip
-                 # Is this still necessary?
-                 if mass_matrix == I && typeof(f) <: Tuple
-                  mass_matrix = ((I for i in 1:length(f))...,)
-                 end
                  if jac == nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
                   if iip
                     jac = update_coefficients! #(J,u,p,t)

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -317,7 +317,7 @@ function RODEFunction{iip,true}(f;
                     jac = (u,p,t) -> update_coefficients!(deepcopy(jac_prototype),u,p,t)
                   end
                  end
-                 RODEFunction{iip,typeof(f),typeof(mass_matrix)
+                 RODEFunction{iip,typeof(f),typeof(mass_matrix),
                  typeof(analytic),typeof(tgrad),
                  typeof(jac),typeof(jac_prototype),typeof(invW),typeof(invW_t),
                  typeof(paramjac),typeof(syms)}(

--- a/src/parameters_interface.jl
+++ b/src/parameters_interface.jl
@@ -3,7 +3,7 @@ function problem_new_parameters(prob::ODEProblem,p;kwargs...)
   u0 = [uEltype(prob.u0[i]) for i in 1:length(prob.u0)]
   tspan = (uEltype(prob.tspan[1]),uEltype(prob.tspan[2]))
   ODEProblem{isinplace(prob)}(prob.f,u0,tspan,p,prob.problem_type;
-  callback = prob.callback, mass_matrix = prob.mass_matrix,
+  callback = prob.callback,
   kwargs...)
 end
 

--- a/src/parameters_interface.jl
+++ b/src/parameters_interface.jl
@@ -12,7 +12,7 @@ function problem_new_parameters(prob::BVProblem,p;kwargs...)
   u0 = [uEltype(prob.u0[i]) for i in 1:length(prob.u0)]
   tspan = (uEltype(prob.tspan[1]),uEltype(prob.tspan[2]))
   BVProblem{isinplace(prob)}(prob.f,prob.bc,u0,tspan,p,prob.problem_type;
-  callback = prob.callback, mass_matrix = prob.mass_matrix,
+  callback = prob.callback,
   kwargs...)
 end
 
@@ -34,7 +34,7 @@ function problem_new_parameters(prob::DDEProblem,p;kwargs...)
   DDEProblem{isinplace(prob)}(prob.f,u0,prob.h,tspan,p;
                               constant_lags = prob.constant_lags,
                               dependent_lags = prob.dependent_lags,
-  callback = prob.callback, mass_matrix = prob.mass_matrix,
+  callback = prob.callback,
   neutral = prob.neutral,
   kwargs...)
 end
@@ -46,7 +46,7 @@ function problem_new_parameters(prob::SDEProblem,p;kwargs...)
   SDEProblem{isinplace(prob)}(prob.f,prob.g,u0,tspan,p;
   noise_rate_prototype = prob.noise_rate_prototype,
   noise= prob.noise, seed = prob.seed,
-  callback = prob.callback,mass_matrix=prob.mass_matrix,
+  callback = prob.callback,
   kwargs...)
 end
 

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -1,6 +1,6 @@
 struct StandardBVProblem end
 
-struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB,MM} <: AbstractBVProblem{uType,tType,isinplace}
+struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB} <: AbstractBVProblem{uType,tType,isinplace}
     f::F
     bc::bF
     u0::uType
@@ -8,16 +8,15 @@ struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB,MM} <: AbstractBVProblem{uTy
     p::P
     problem_type::PT
     callback::CB
-    mass_matrix::MM
     @add_kwonly function BVProblem{iip}(f,bc,u0,tspan,p=nothing,
                             problem_type=StandardBVProblem();
-                            callback=nothing,mass_matrix=I) where {iip}
+                            callback=nothing) where {iip}
         _tspan = promote_tspan(tspan)
         new{typeof(u0),typeof(tspan),iip,typeof(p),
                   typeof(f),typeof(bc),
-                  typeof(problem_type),typeof(callback),typeof(mass_matrix)}(
+                  typeof(problem_type),typeof(callback)}(
                   f,bc,u0,_tspan,p,
-                  problem_type,callback,mass_matrix)
+                  problem_type,callback)
     end
 end
 

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -1,4 +1,4 @@
-struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C,MM} <:
+struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
                           AbstractDDEProblem{uType,tType,lType,isinplace}
   f::F
   u0::uType
@@ -8,25 +8,23 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C,MM} <:
   constant_lags::lType
   dependent_lags::lType2
   callback::C
-  mass_matrix::MM
   neutral::Bool
   @add_kwonly function DDEProblem(f::AbstractDDEFunction,
                                  u0,h,tspan,p=nothing;
                                  constant_lags=[],
                                  dependent_lags=[],
-                                 mass_matrix=I,
-                                 neutral = mass_matrix == I ?
-                                           false : det(mass_matrix)!=1,
+                                 neutral = f.mass_matrix == I ?
+                                           false : det(f.mass_matrix)!=1,
                                  callback = nothing)
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),
                typeof(constant_lags),typeof(dependent_lags),
                isinplace(f),typeof(p),
-               typeof(f),typeof(h),typeof(callback),
-               typeof(mass_matrix)}(f,u0,h,_tspan,p,
-                                    constant_lags,
-                                    dependent_lags,callback,
-                                    mass_matrix,neutral)
+               typeof(f),typeof(h),typeof(callback)
+               }(f,u0,h,_tspan,p,
+                 constant_lags,
+                 dependent_lags,callback,
+                 neutral)
   end
 
   function DDEProblem{iip}(f,u0,h,tspan,p=nothing;kwargs...) where {iip}

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -34,14 +34,14 @@ abstract type AbstractDynamicalODEProblem end
 struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
 # u' = f1(v)
 # v' = f2(t,u)
-function DynamicalODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;mass_matrix=(I,I),kwargs...)
-  ODEProblem(f,(du0,u0),tspan,p;mass_matrix=mass_matrix,kwargs...)
+function DynamicalODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;kwargs...)
+  ODEProblem(f,(du0,u0),tspan,p;kwargs...)
 end
-function DynamicalODEProblem(f1,f2,du0,u0,tspan,p=nothing;mass_matrix=(I,I),kwargs...)
-  ODEProblem(DynamicalODEFunction(f1,f2),(du0,u0),tspan,p;mass_matrix=mass_matrix,kwargs...)
+function DynamicalODEProblem(f1,f2,du0,u0,tspan,p=nothing;kwargs...)
+  ODEProblem(DynamicalODEFunction(f1,f2),(du0,u0),tspan,p;kwargs...)
 end
-function DynamicalODEProblem{iip}(f1,f2,du0,u0,tspan,p=nothing;mass_matrix=(I,I),kwargs...) where iip
-  ODEProblem(DynamicalODEFunction{iip}(f1,f2),(du0,u0),tspan,p;mass_matrix=mass_matrix,kwargs...)
+function DynamicalODEProblem{iip}(f1,f2,du0,u0,tspan,p=nothing;kwargs...) where iip
+  ODEProblem(DynamicalODEFunction{iip}(f1,f2),(du0,u0),tspan,p;kwargs...)
 end
 
 # u'' = f(t,u,du,ddu)
@@ -77,10 +77,10 @@ function SecondOrderODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;kw
         v
       end
     end
-    return ODEProblem(DynamicalODEFunction{iip}(f.f1,f2;analytic=f.analytic),_u0,tspan,p,
+    return ODEProblem(DynamicalODEFunction{iip}(f.f1,f2;mass_matrix=f.mass_matrix,analytic=f.analytic),_u0,tspan,p,
                   SecondOrderODEProblem{iip}();kwargs...)
   else
-    return ODEProblem(DynamicalODEFunction{iip}(f.f1,f.f2;analytic=f.analytic),_u0,tspan,p,
+    return ODEProblem(DynamicalODEFunction{iip}(f.f1,f.f2;mass_matrix=f.mass_matrix,analytic=f.analytic),_u0,tspan,p,
                   SecondOrderODEProblem{iip}();kwargs...)
   end
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -1,29 +1,23 @@
 struct StandardODEProblem end
 
 # Mu' = f
-struct ODEProblem{uType,tType,isinplace,P,F,C,MM,PT} <:
+struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
                AbstractODEProblem{uType,tType,isinplace}
   f::F
   u0::uType
   tspan::tType
   p::P
   callback::C
-  mass_matrix::MM
   problem_type::PT
   @add_kwonly function ODEProblem(f::AbstractODEFunction,u0,tspan,p=nothing,
                       problem_type=StandardODEProblem();
-                      callback=nothing,mass_matrix=I)
+                      callback=nothing)
     _tspan = promote_tspan(tspan)
-    if mass_matrix == I && typeof(f) <: Tuple
-      _mm = ((I for i in 1:length(f))...,)
-    else
-      _mm = mass_matrix
-    end
     new{typeof(u0),typeof(_tspan),
        isinplace(f),typeof(p),typeof(f),
-       typeof(callback),typeof(_mm),
+       typeof(callback),
        typeof(problem_type)}(
-       f,u0,_tspan,p,callback,_mm,problem_type)
+       f,u0,_tspan,p,callback,problem_type)
   end
 
   function ODEProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -101,7 +101,7 @@ SplitODEProblem(f::SplitFunction,u0,tspan,p=nothing;kwargs...) =
 function SplitODEProblem{iip}(f::SplitFunction,u0,tspan,p=nothing;kwargs...) where iip
   if f.cache == nothing && iip
     cache = similar(u0)
-    f = SplitFunction{iip}(f.f1, f.f2;
+    f = SplitFunction{iip}(f.f1, f.f2; mass_matrix=f.mass_matrix,
                      _func_cache=cache, analytic=f.analytic)
   end
   ODEProblem(f,u0,tspan,p,SplitODEProblem{iip}();kwargs...)

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,24 +1,23 @@
-mutable struct RODEProblem{uType,tType,isinplace,P,NP,F,C,MM,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
+mutable struct RODEProblem{uType,tType,isinplace,P,NP,F,C,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
   f::F
   u0::uType
   tspan::tType
   p::P
   noise::NP
   callback::C
-  mass_matrix::MM
   rand_prototype::ND
   seed::UInt64
   @add_kwonly function RODEProblem(f::RODEFunction,u0,tspan,p=nothing;
                        rand_prototype = nothing,
                        noise= nothing, seed = UInt64(0),
-                       callback=nothing,mass_matrix=I)
+                       callback=nothing)
   _tspan = promote_tspan(tspan)
   new{typeof(u0),typeof(_tspan),
               isinplace(f),typeof(p),
               typeof(noise),typeof(f),typeof(callback),
-              typeof(mass_matrix),typeof(rand_prototype)}(
+              typeof(rand_prototype)}(
               f,u0,_tspan,p,noise,callback,
-              mass_matrix,rand_prototype,seed)
+              rand_prototype,seed)
   end
   function RODEProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}
     RODEProblem(convert(RODEFunction{iip},f),u0,tspan,p;kwargs...)

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -1,6 +1,6 @@
 struct StandardSDEProblem end
 
-struct SDEProblem{uType,tType,isinplace,P,NP,F,G,C,MM,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
+struct SDEProblem{uType,tType,isinplace,P,NP,F,G,C,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
   f::F
   g::G
   u0::uType
@@ -8,28 +8,22 @@ struct SDEProblem{uType,tType,isinplace,P,NP,F,G,C,MM,ND} <: AbstractSDEProblem{
   p::P
   noise::NP
   callback::C
-  mass_matrix::MM
   noise_rate_prototype::ND
   seed::UInt64
   @add_kwonly function SDEProblem(f::AbstractSDEFunction,g,u0,
           tspan,p=nothing,problem_type=StandardSDEProblem();
           noise_rate_prototype = nothing,
           noise= nothing, seed = UInt64(0),
-          callback = nothing,mass_matrix=I)
+          callback = nothing)
     _tspan = promote_tspan(tspan)
-    if mass_matrix == I && typeof(f) <: Tuple
-      _mm = ((I for i in 1:length(f))...,)
-    else
-      _mm = mass_matrix
-    end
 
     new{typeof(u0),typeof(_tspan),
         isinplace(f),typeof(p),
         typeof(noise),typeof(f),typeof(f.g),
-        typeof(callback),typeof(_mm),
+        typeof(callback),
         typeof(noise_rate_prototype)}(
         f,f.g,u0,_tspan,p,
-        noise,callback,_mm,
+        noise,callback,
         noise_rate_prototype,seed)
   end
 
@@ -58,5 +52,5 @@ end
 function SplitSDEProblem{iip}(f1,f2,g,u0,tspan,p=nothing;
                                      func_cache=nothing,kwargs...) where iip
   iip ? _func_cache = similar(u0) : _func_cache = nothing
-  SDEProblem{iip}(SplitFunction{iip}(f1,f2,_func_cache),g,u0,tspan,p,SplitSDEProblem{iip}();kwargs...)
+  SDEProblem{iip}(SplitFunction{iip}(f1,f2;_func_cache=_func_cache),g,u0,tspan,p,SplitSDEProblem{iip}();kwargs...)
 end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,13 +1,11 @@
 # Mu' = f
-struct SteadyStateProblem{uType,isinplace,P,F,MM} <: AbstractSteadyStateProblem{uType,isinplace}
+struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
   f::F
   u0::uType
   p::P
-  mass_matrix::MM
-  @add_kwonly function SteadyStateProblem{iip}(f,u0,p=nothing;
-                                   mass_matrix=I) where iip
+  @add_kwonly function SteadyStateProblem{iip}(f,u0,p=nothing) where iip
     new{typeof(u0),iip,typeof(p),
-        typeof(f),typeof(mass_matrix)}(f,u0,p,mass_matrix)
+        typeof(f)}(f,u0,p)
   end
 end
 
@@ -17,4 +15,4 @@ function SteadyStateProblem(f,u0,p=nothing;kwargs...)
 end
 
 SteadyStateProblem(prob::AbstractODEProblem) =
-      SteadyStateProblem{isinplace(prob)}(prob.f,prob.u0,mass_matrix=prob.mass_matrix)
+      SteadyStateProblem{isinplace(prob)}(prob.f,prob.u0)

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -26,14 +26,13 @@ u0 = ones(2)
 tspan = (0,1.0)
 
 # Create a ODEProblem and test remake:
-prob1 = SplitODEProblem(f,f,u0,tspan,Dict(); mass_matrix=Matrix(I, length(u0), length(u0)))
+prob1 = SplitODEProblem(f,f,u0,tspan,Dict())
 prob2 = remake(prob1; u0 = prob1.u0 .+ 1)
 @test prob1.f === prob2.f
 @test prob1.p === prob2.p
 @test prob1.u0 .+ 1 ≈ prob2.u0
 @test prob1.tspan == prob2.tspan
 @test prob1.callback === prob2.callback
-@test prob1.mass_matrix === prob2.mass_matrix
 @test prob1.problem_type === prob2.problem_type
 
 # Test remake with SplitFunction:


### PR DESCRIPTION
These are the proposed changes to how mass matrix should be handled in DiffEq. Basically, the `mass_matrix` field is no longer stored as a field of `*DEProblem` but instead `*DEFunction`.

The main reason for these changes is to make sparse/lazy W operator handling in OrdinaryDiffEq simpler https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/416#issuecomment-405622364. Apart from this, there are also be cases where knowing what the mass matrix is solely by querying the `*DEFunction` might help. One case I can think of is converting a problem with non-unity mass matrix to a regular problem, i.e. `Mu' = f(u)` -> `u' = M^(-1)f(u) = g(u)`. Since a lot of integrators do not use the mass matrix explicitly (e.g. the ExpRK integrators) this can come handy. By storing `mass_matrix` in `ODEFunction` we can do something like:

```julia
function convert_canonical(fun::ODEFunction)
  f = (u,p,t) -> M \ fun.f(u,p,t)
  ODEFunction(f; mass_matrix=I, analytic=fun.analytic, ...)
end
```

An additional benefit is when a single `*DEProblem` type support multiple `*DEFucntion`. For example, `DynamicalProblem`, `SecondOrderODEProblem` and `SplitODEProblem` are all `ODEProblem` in disguise, each with their own `*DEFunction` type. Whereas previously `ODEProblem.mass_matrix` need to handle all these cases, now the mass matrices are handled by the functions and can thus allow specialization (e.g. in `calc_W!`).

These changes are only the first step though. @ChrisRackauckas can you create a new branch for DiffEqBase with these changes, so that I can update OrdinaryDiffEq and other packages using it as a base? 