### PR TITLE
Fix plot(sol, tspan=...)

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -78,8 +78,8 @@ DEFAULT_PLOT_FUNC(x,y,z) = (x,y,z) # For v0.5.2 bug
     end
     start_idx = 1
   else
-    start_idx = something(findfirst(isequal(sol.t), x -> x>=tspan[end]), 0)
-    end_idx = something(findfirst(isequal(sol.t), x -> x<=tspan[end]), 0)
+    start_idx = something(findfirst(x -> x>=tspan[1], sol.t), 1)
+    end_idx = something(findlast(x -> x<=tspan[end], sol.t), length(sol))
   end
 
   # determine type of spacing for plott


### PR DESCRIPTION
Otherwise you get error like `MethodError(keys, (getfield(DiffEqBase, Symbol("##78#84"))(Core.Box((70, 90))),), 0x0000000000006c9b)`.  I'm sending a PR to 07-fix branch since Plots.jl is not ready yet for 1.0.

It fixes some semantics of the previous code.  Reading the code history, I _guess_ this is the correct implementation.  But rest of the plotting function is so large and I'm not 100% sure about this...
