### PR TITLE
Improve recursivecopy! and copy_fields! considering the types when copying

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,6 @@ RecursiveArrayTools 0.12.3
 Compat 0.19.0
 Requires
 IteratorInterfaceExtensions 0.1.0
+StaticArrays 0.8.3
 TableTraits 0.3.0
 TreeViews

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -14,6 +14,8 @@ import RecursiveArrayTools: chain
 
 import LinearAlgebra: exp, ldiv!
 
+import StaticArrays: SArray
+
 import Statistics: mean, median
 
 # Problems

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -76,12 +76,28 @@ Arrays are recursively copied.
 """
 @generated function copy_fields!(dest::T, src::T2) where
     {T<:DEDataArray,T2<:DEDataArray}
-    assignments = [(sq = Meta.quot(s);
-                    :(typeof(getfield(dest, $sq)) <: AbstractArray ?
-                      recursivecopy!(getfield(dest, $sq), getfield(src, $sq)) :
-                      setfield!(dest, $sq, deepcopy(getfield(src, $sq)))))
-                   for s in fieldnames(dest) if s != :x]
-    :($(assignments...); dest)
+
+    fields = fieldnames(src)
+
+    expressions = Vector{Expr}(undef, length(fields))
+
+    @inbounds for i = 1:length(fields)
+        f  = fields[i]
+        Tf = src.types[i]
+        qf = Meta.quot(f)
+
+        if f == :x
+            expressions[i] = :( )
+        elseif Tf <: Union{Number,SArray}
+            expressions[i] = :( dest.$f = getfield( src, $qf ) )
+        elseif Tf <: AbstractArray
+            expressions[i] = :( recursivecopy!(dest.$f, getfield( src, $qf ) ) )
+        else
+            expressions[i] = :( dest.$f = deepcopy( getfield( src, $qf ) ) )
+        end
+    end
+
+    :($(expressions...); dest)
 end
 
 ################# Overloads for stiff solvers ##################################

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -34,12 +34,25 @@ end
 Recursively copy fields of `src` to `dest`.
 """
 @generated function recursivecopy!(dest::T, src::T) where {T<:DEDataArray}
-    assignments = [(sq = Meta.quot(s);
-                   :(typeof(getfield(dest, $sq)) <: AbstractArray ?
-                     recursivecopy!(getfield(dest, $sq), getfield(src, $sq)) :
-                     setfield!(dest, $sq, deepcopy(getfield(src, $sq)))))
-                   for s in fieldnames(dest)]
-    :($(assignments...); dest)
+    fields = fieldnames(src)
+
+    expressions = Vector{Expr}(undef, length(fields))
+
+    @inbounds for i = 1:length(fields)
+        f  = fields[i]
+        Tf = src.types[i]
+        qf = Meta.quot(f)
+
+        if Tf <: Union{Number,SArray}
+            expressions[i] = :( dest.$f = getfield( src, $qf ) )
+        elseif Tf <: AbstractArray
+            expressions[i] = :( recursivecopy!(dest.$f, getfield( src, $qf ) ) )
+        else
+            expressions[i] = :( dest.$f = deepcopy( getfield( src, $qf ) ) )
+        end
+    end
+
+    :($(expressions...); dest)
 end
 
 """

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -69,10 +69,10 @@ value in `template`.
 end
 
 """
-    copy_fields!(dest::T, src::T) where {T<:DEDataArray}
+    copy_fields!(dest::T, src::T2) where {T<:DEDataArray,T2<:DEDataArray}
 
-Replace all fields of `dest` except of its wrapped array with a copy of the value in `src`.
-Arrays are recursively copied.
+Replace all fields of `dest` except of its wrapped array with a copy of the
+value in `src`. Arrays are recursively copied.
 """
 @generated function copy_fields!(dest::T, src::T2) where
     {T<:DEDataArray,T2<:DEDataArray}


### PR DESCRIPTION
Hi!

With this PR, the functions `recursivecopy!` and `copy_fields!` are improved by considering the field type when copying.

This partially fixes the bug JuliaDiffEq/DifferentialEquations.jl#336, because it is now possible to use `SArray` as a field type in `DEDataVector`.