### PR TITLE
Fix BVProblem constructor

### DIFF
--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -8,7 +8,7 @@ struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB} <: AbstractBVProblem{uType,
     p::P
     problem_type::PT
     callback::CB
-    @add_kwonly function BVProblem{iip}(f,bc,u0,tspan,p=nothing,
+    @add_kwonly function BVProblem{iip}(f::AbstractODEFunction,bc,u0,tspan,p=nothing,
                             problem_type=StandardBVProblem();
                             callback=nothing) where {iip}
         _tspan = promote_tspan(tspan)
@@ -18,11 +18,18 @@ struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB} <: AbstractBVProblem{uType,
                   f,bc,u0,_tspan,p,
                   problem_type,callback)
     end
+
+    function BVProblem{iip}(f,bc,u0,tspan,p=nothing;kwargs...) where {iip}
+        BVProblem(convert(ODEFunction{iip},f),bc,u0,tspan,p;kwargs...)
+      end
 end
 
-function BVProblem(f,bc,u0::AbstractArray,tspan,p=nothing;kwargs...)
-    iip = DiffEqBase.isinplace(f,4)
-    BVProblem{iip}(f,bc,u0,tspan,p;kwargs...)
+function BVProblem(f::AbstractODEFunction,bc,u0,tspan,args...;kwargs...)
+    BVProblem{DiffEqBase.isinplace(f,4)}(f,bc,u0,tspan,args...;kwargs...)
+end
+  
+function BVProblem(f,bc,u0,tspan,p=nothing;kwargs...)
+    BVProblem(convert(ODEFunction,f),bc,u0,tspan,p;kwargs...)
 end
 
 # convenience interfaces:


### PR DESCRIPTION
The first example (pendulum) in the [docs](http://docs.juliadiffeq.org/latest/tutorials/bvp_example.html) threw the following error:
```julia
ERROR: MethodError: no method matching has_analytic(::typeof(simplependulum!))
Closest candidates are:
  has_analytic(::DiffEqBase.AbstractDiffEqFunction) at C:\Users\Attila\.julia\packages\DiffEqBase\YSk7M\src\diffeqfunction.jl:466
```
I checked the commits and it seems the constructor for the `BVProblem` was not updated in PR #147, so the input function is not converted to the `ODEFunction`.
With these changes the example now works properly and it seems I did not break anything, however feel free to comment if this messes up anything else.