### PR TITLE
Fix sensitivities and don't require time to be dual valued

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -7,12 +7,14 @@ function __init__()
     @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N}) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
     end
+    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual) = abs(ForwardDiff.value(u))
   end
 
   @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N}) where {N}
-      sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Measurements.Measurement,N}) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(Measurements.value(x) for x in u)) / length(u))
     end
+    @inline ODE_DEFAULT_NORM(u::Measurements.Measurement) = abs(Measurements.value(u))
   end
 
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -4,34 +4,14 @@ function __init__()
   end
 
   @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
-    function dual_number_warn(u0::AbstractArray{<:ForwardDiff.Dual},tspan::Tuple{T,T}) where T<:Number
-      if !(T<:ForwardDiff.Dual)
-        @warn("Both the initial condition and time values must be Dual numbers in order to be compatible with Dual number inputs. Change the element type of tspan to match the element type of u0.")
-      end
-    end
-    function dual_number_warn(u0::AbstractArray{<:Number},tspan::Tuple{T,T}) where T<:ForwardDiff.Dual
-      if !(eltype(u0)<:ForwardDiff.Dual)
-        @warn("Both the initial condition and time values must be Dual numbers in order to be compatible with Dual number inputs. Change the element type of u0 to match the element type of tspan.")
-      end
-    end
-    function dual_number_warn(u0::AbstractArray{<:ForwardDiff.Dual},tspan::Tuple{T,T}) where T<:ForwardDiff.Dual
-      nothing
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N}) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
     end
   end
 
   @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin
-    function measurements_warn(u0::AbstractArray{<:Measurements.Measurement},tspan::Tuple{T,T}) where T<:Number
-      if !(T<:Measurements.Measurement)
-        @warn("Both the initial condition and time values must be Measurements in order to be compatible with Measurement inputs. Change the element type of tspan to match the element type of u0.")
-      end
-    end
-    function measurements_warn(u0::AbstractArray{<:Number},tspan::Tuple{T,T}) where T<:Measurements.Measurement
-      if !(eltype(u0)<:Measurements.Measurement)
-        @warn("Both the initial condition and time values must be Measurements in order to be compatible with Measurement inputs. Change the element type of u0 to match the element type of tspan.")
-      end
-    end
-    function measurements_warn(u0::AbstractArray{<:Measurements.Measurement},tspan::Tuple{T,T}) where T<:Measurements.Measurement
-      nothing
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N}) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
     end
   end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -79,6 +79,3 @@ function adaptive_integer_warn(tspan)
     @warn("Integer time values are incompatible with adaptive integrators. Utilize floating point numbers instead of integers in this case, i.e. (0.0,1.0) instead of (0,1).")
   end
 end
-
-dual_number_warn(u0,tspan) = nothing
-measurements_warn(u0,tspan) = nothing

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -72,8 +72,6 @@ handle_distribution_u0(_u0) = _u0
 
 function adaptive_warn(u0,tspan)
   adaptive_integer_warn(tspan)
-  dual_number_warn(u0,tspan)
-  measurements_warn(u0,tspan)
 end
 
 function adaptive_integer_warn(tspan)


### PR DESCRIPTION
This deserves an explanation. While fixing https://github.com/JuliaDiffEq/DiffEqSensitivity.jl/issues/24 I noticed that using dual numbers to get sensitivities worked with `saveat` but could give incorrect values on the directly saved values. This seemed odd, and I tracked it down to being due to adaptive time stepping by turning off adaptivity and seeing it go away. `saveat` values have no sensitivity/uncertainty in time, so that made sense as well.

But to fix it, I implemented the change of this PR. What this essentially does is it separates time from the dual valued state space. This has been a long running noted oddity that in order to differentiate you needed to set time to dual numbers as well (though this issue points out it was only correct with `saveat`, which all parameter fitting used so it went unnoticed before). This has always been troubling since the ODE solver itself is not a differentiable algorithm, but it kind of worked. The way that https://github.com/JuliaDiffEq/DiffEqSensitivity.jl/issues/24 failed though is that the sensitivities were correct until the first step rejection, showing that the non-differentiability was indeed an issue.

However, the adaptive algorithm's only input from state is the norm of the error. Basically you can think of it as, given the norm of the error calculate what the new time steps should be (or whether the current step should be rejected and reduced, the non-differentiable part). If you think of the time steps as given, then the solver with pre-determined time steps is a differentiable program. By declaring the norm values to be not related to the sensitivities, they are in a sense given without reference to the dual numbers and thus the program for the state values is differentiable and this all works.

It's a little bit more difficult than that because we can use a norm which for example adds the norm of the dual and value parts. As long as said norm isn't a dual number it's fine. You can think of this as a differentiable program with a control, and the duals shouldn't propogate through the controls which just pick the next `dt`, and it can or cannot use the duals in said controls as it pleases since the true solution is independent of the choice `dt`. Thus in some sense, this program, the full ODE solver, lives in a space that's larger than the set of differentiable programs but is ADable. I didn't realize that before but it's kind of cool.

Anyways, the following code now works:

```julia
using ForwardDiff
using ForwardDiff: Partials, Dual
using OrdinaryDiffEq
using Plots
using Calculus

#forward differentiation
function func(du,u,p,t)
  du[1] = p[1] * u[1] - p[2] * u[1]*u[2]
  du[2] = -3 * u[2] + u[1]*u[2]
end
p1 = 1.5
p2 = 1.0
u0 = [1.0, 1.0]
tspan = (0.0,10.0)
p = [p1, p2]

p1dual = Dual{Float64}(p1, (1.0, 0.0))
p2dual = Dual{Float64}(p2, (0.0, 1.0))
pdual = [p1dual, p2dual]
prob_dual = ODEProblem(func,eltype(pdual).(u0),tspan,pdual)
sol_dual = solve(prob_dual,Tsit5(),saveat=0.0:0.1:10.0, reltol = 1e-15)
sol_dual2 = solve(prob_dual,Tsit5(), reltol = 1e-15)

timepoints = [i for i in sol_dual.t]
sensitivity_forward_diff = [i[1].partials.values[1] for i in sol_dual.u]
Plots.plot(timepoints,sensitivity_forward_diff)

timepoints = [i for i in sol_dual2.t]
sensitivity_forward_diff = [i[1].partials.values[1] for i in sol_dual2.u]
Plots.plot!(timepoints,sensitivity_forward_diff)

using ParameterizedFunctions
# sensitivity ODE
f_ode_sen = @ode_def_nohes test_sensitivity begin
  du1 = p1 * u1 - p2 * u1*u2
  du2 = -3 * u2 + u1*u2
end p1 p2

prob_ode_sen = ODELocalSensitivityProblem(f_ode_sen,u0,tspan,p)
sol_ode_state_and_sen = solve(prob_ode_sen,Tsit5(),reltol = 1e-9)

timepoints2 = [i for i in sol_ode_state_and_sen.t]
sensitivity_ode_sol = [i[3] for i in sol_ode_state_and_sen.u]
state_ode_sol = [i[3] for i in sol_ode_state_and_sen.u]
Plots.plot!(timepoints2,sensitivity_ode_sol)
```

![sensitivity_plot](https://user-images.githubusercontent.com/1814174/45922170-9c747c00-be79-11e8-94cb-be5bb4b53ac1.png)

Time doesn't need to be made dual in order for the solver to work with things like ForwardDiff. This should also make things easier for a lot of users. Additionally, Measurements now also work without time-based measurements as well:

```julia
using OrdinaryDiffEq, Measurements
# Half-life of radiocarbon, in thousands of years
c = 5.730 ± 0.040

#Setup
u₀ = 1 ± 0
tspan = (0.0, 1.0)

#Define the problem
radioactivedecay(u,p,t) = -c * u

#Pass to solver
prob = ODEProblem(radioactivedecay, u₀, tspan)
sol = solve(prob, Tsit5())
```

Pinging all of those who will care about this change and its discussion. @tkoolen @jrevels @ArnoJL @giordano @SebastianM-C  & https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/419, @dkarrasch 
& https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/225,  https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/202, @YingboMa , @Vaibhavdixit02 .