### PR TITLE
logspace replace by base.^range(..)

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -85,7 +85,7 @@ DEFAULT_PLOT_FUNC(x,y,z) = (x,y,z) # For v0.5.2 bug
   # determine type of spacing for plott
   tscale = get(plotattributes, :xscale, :identity)
   densetspacer = if tscale in [:ln, :log10, :log2]
-    (start, stop, n) -> logspace(log10(start), log10(stop), n)
+    (start, stop, n) -> 10.0.^range(log10(start), stop=log10(stop), length=n)
   else
     (start, stop, n) -> range(start;stop=stop,length=n)
   end


### PR DESCRIPTION
`logspace` does not work anymore in Julia 1.0. I replaced it with `10.0^range(...)` because of an error when using `plot` from Plots.jl