### PR TITLE
Make save_positions mutable

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -10,9 +10,17 @@ struct ContinuousCallback{F1,F2,F3,F4,T,T2,I} <: AbstractContinuousCallback
   idxs::I
   rootfind::Bool
   interp_points::Int
-  save_positions::Tuple{Bool,Bool}
+  save_positions::BitArray{1}
   abstol::T
   reltol::T2
+  ContinuousCallback(condition::F1,affect!::F2,affect_neg!::F3,
+                     initialize::F4,idxs::I,rootfind,
+                     interp_points,save_positions,abstol::T,reltol::T2) where {F1,F2,F3,F4,T,T2,I} =
+                       new{F1,F2,F3,F4,T,T2,I}(condition,
+                                               affect!,affect_neg!,
+                                               initialize,idxs,rootfind,interp_points,
+                                               BitArray(collect(save_positions)),
+                                               abstol,reltol)
 end
 
 ContinuousCallback(condition,affect!,affect_neg!;
@@ -39,7 +47,7 @@ function ContinuousCallback(condition,affect!;
  ContinuousCallback(
             condition,affect!,affect_neg!,initialize,idxs,
             rootfind,interp_points,
-            save_positions,abstol,reltol)
+            collect(save_positions),abstol,reltol)
 
 end
 
@@ -47,7 +55,11 @@ struct DiscreteCallback{F1,F2,F3} <: AbstractDiscreteCallback
   condition::F1
   affect!::F2
   initialize::F3
-  save_positions::Tuple{Bool,Bool}
+  save_positions::BitArray{1}
+  DiscreteCallback(condition::F1,affect!::F2,
+                   initialize::F3,save_positions) where {F1,F2,F3} = new{F1,F2,F3}(condition,
+                                                                                   affect!,initialize,
+                                                                                   BitArray(collect(save_positions)))
 end
 DiscreteCallback(condition,affect!;
         initialize = INITIALIZE_DEFAULT,save_positions=(true,true)) = DiscreteCallback(condition,affect!,initialize,save_positions)


### PR DESCRIPTION
This PR makes the `save_positions` field in the callback struct mutable, which would give users more control on the saving behavior.

Tests passed locally on my laptop.

```julia
julia> @time @testset_module "Events Tests" begin include("ode/ode_event_tests.jl") end
Test Summary: | Pass  Total
Events Tests  |   20     20
 28.007802 seconds (63.18 M allocations: 3.115 GiB, 5.81% gc time)
```