### PR TITLE
Pass p of ODEProblem to SteadyStateProblem

### DIFF
--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -22,4 +22,4 @@ function SteadyStateProblem(f,u0,p=nothing;kwargs...)
 end
 
 SteadyStateProblem(prob::AbstractODEProblem) =
-      SteadyStateProblem{isinplace(prob)}(prob.f,prob.u0)
+      SteadyStateProblem{isinplace(prob)}(prob.f,prob.u0,prob.p)

--- a/test/problem_creation_tests.jl
+++ b/test/problem_creation_tests.jl
@@ -93,3 +93,4 @@ u0 = zeros(2)
 prob = SteadyStateProblem(f,u0)
 
 @test_broken @inferred SteadyStateProblem(f,u0)
+@test SteadyStateProblem(ODEProblem(f,u0,tspan,:param)).p == :param


### PR DESCRIPTION
Is it OK to assume `prob.p` exists for any `AbstractODEProblem`?