### PR TITLE
use callback tolerance from last event

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -177,7 +177,7 @@ end
     @views previous_condition = callback.condition(integrator.uprev[callback.idxs],integrator.tprev,integrator)
   end
 
-  if integrator.event_last_time == counter && abs(previous_condition) < 100callback.abstol
+  if integrator.event_last_time == counter && abs(previous_condition) < 100abs(integrator.last_event_error)
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then
@@ -250,7 +250,7 @@ function find_callback_time(integrator,callback,counter)
           Θ = top_Θ
         else
           if integrator.event_last_time == counter &&
-            abs(zero_func(bottom_θ)) < 100callback.abstol &&
+            abs(zero_func(bottom_θ)) < 100abs(integrator.last_event_error) &&
             prev_sign_index == 1
 
             # Determined that there is an event by derivative
@@ -266,6 +266,7 @@ function find_callback_time(integrator,callback,counter)
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
           Θ = prevfloat(Roots.find_zero(zero_func,(bottom_θ,top_Θ),Roots.AlefeldPotraShi(),atol = callback.abstol/100))
+          integrator.last_event_error = zero_func(Θ)
         end
         #Θ = prevfloat(...)
         # prevfloat guerentees that the new time is either 1 floating point


### PR DESCRIPTION
I've been griping about the issue is that the tolerance is impossible to set because it's not dependent on `t` but the callback function itself. Examples:

```
using Roots
f(x) = exp(x) - x^4
x = find_zero(f, (8,9), Roots.AlefeldPotraShi())
f(x) # 9.094947017729282e-13
f(nextfloat(x)) # 7.275957614183426e-12
f(prevfloat(x)) # -1.8189894035458565e-12

f(x) = 1e8 - (x+5)^11
x = find_zero(f, (0,16), Roots.AlefeldPotraShi(), atol = 0)
f(x) # 2.9802322387695312e-8
f(nextfloat(x)) # -1.4901161193847656e-7
f(prevfloat(x)) # 2.9802322387695312e-8

f(x) = 100000000000000*(x-8)
f(8.0) # 0.0
f(prevfloat(8.0)) #-0.08881784197001252
f(nextfloat(8.0)) #0.17763568394002505
```

Then it dawned on me that we can just use the callback's output itself as its next tolerance. If we always prevfloat, then the value won't be zero so we're fine. We don't want it to be zero since if it is then we have no idea how close it could be in the next interval (we have no tolerance idea). One update in the future could adaptively choose to prevfloat or not, and then take the zero while keeping the good tolerance estimate. There are times in this current strategy where we are exactly one floating point number off from the zero when we could be exactly on it, but that's rare (most of the time hitting the zero is impossible) and I'm not sure users will care about 1 floating point number difference (if they do, they should be using bigfloats), so IMO it's not an issue to actually worry about.

For multiple callbacks, the event_last_time is checked against the counter, so this tolerance is only applied to a callback call of itself, alleviating issues of matching different root functions with different slopes. 

I will say this is not technically breaking since the solvers haven't been updated to use the generic callback handling yet (on any release versions). The integrators all need a new field, but this can be done in the PRs that enable the callback handling, so we're safe. 