### PR TITLE
`savevalues!` should return booleans

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -298,12 +298,12 @@ function apply_callback!(integrator,callback::ContinuousCallback,cb_time,prev_si
   change_t_via_interpolation!(integrator,integrator.tprev+cb_time)
 
   # handle saveat
-  savevalues!(integrator)
+  _, savedexactly = savevalues!(integrator)
   saved_in_cb = true
 
   @inbounds if callback.save_positions[1]
     # if already saved then skip saving
-    last(integrator.sol.t) == integrator.t || savevalues!(integrator,true)
+    savedexactly || savevalues!(integrator,true)
   end
 
   integrator.u_modified = true
@@ -338,11 +338,11 @@ end
   saved_in_cb = false
   if callback.condition(integrator.u,integrator.t,integrator)
     # handle saveat
-    savevalues!(integrator)
+    _, savedexactly = savevalues!(integrator)
     saved_in_cb = true
     @inbounds if callback.save_positions[1]
       # if already saved then skip saving
-      last(integrator.sol.t) == integrator.t || savevalues!(integrator,true)
+      savedexactly || savevalues!(integrator,true)
     end
     integrator.u_modified = true
     callback.affect!(integrator)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -25,6 +25,22 @@ get_du!(out,i::DEIntegrator) = error("get_du: method has not been implemented fo
 get_dt(i::DEIntegrator) = error("get_dt: method has not been implemented for the integrator")
 get_proposed_dt(i::DEIntegrator) = error("get_proposed_dt: method has not been implemented for the integrator")
 set_proposed_dt!(i::DEIntegrator) = error("modify_proposed_dt!: method has not been implemented for the integrator")
+"""
+    savevalues!(integrator::DEIntegrator,
+      force_save=false) -> Tuple{Bool, Bool}
+
+Try to save the state and time variables at the current time point, or the
+`saveat` point by using interpolation when appropriate. It returns a tuple that
+is `(saved, savedexactly)`. If `savevalues!` saved value, then `saved` is true,
+and if `savevalues!` saved at the current time point, then `savedexactly` is
+true.
+
+The saving priority/order is as follows:
+  - `save_on`
+    - `saveat`
+    - `force_save`
+    - `save_everystep`/`timeseries_steps`
+"""
 u_modified!(i::DEIntegrator,bool) = error("u_modified!: method has not been implemented for the integrator")
 savevalues!(i::DEIntegrator) = error("savevalues!: method has not been implemented for the integrator")
 add_tstop!(i::DEIntegrator,t) = error("add_tstop!: method has not been implemented for the integrator")


### PR DESCRIPTION
The reason that we are doing this is that checking `last(integrator.sol.t) == integrator.t` is not a nice solution. Instead, we can just make `savevalues!` return `saved, savedexactly`. This PR can be merged after merging and tagging https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/544, https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/86, https://github.com/JuliaDiffEq/StochasticDiffEq.jl/pull/113, https://github.com/JuliaDiffEq/Sundials.jl/pull/191, and https://github.com/JuliaDiffEq/ODEInterfaceDiffEq.jl/pull/15. In this way, we won't introduce any breaking changes.

All tests passed locally:
```julia
julia> @time @safetestset "Event Tests" begin
           home = homedir()
           rt = "$home/.julia/dev"
           cdir = pwd()
           cd(rt)
           println("OrdinaryDiffEq")
           @safetestset "OrdinaryDiffEq" begin include("OrdinaryDiffEq/test/ode/ode_event_tests.jl") end
           println("DelayDiffEq")
           @safetestset "DelayDiffEq" begin include("DelayDiffEq/test/events.jl") end
           println("StochasticDiffEq")
           @safetestset "StochasticDiffEq" begin include("StochasticDiffEq/test/events_test.jl") end
           println("Sundials")
           @safetestset "Sundials" begin include("Sundials/test/common_interface/callbacks.jl") end
           println("ODEInterfaceDiffEq")
           @safetestset "ODEInterfaceDiffEq" begin include("ODEInterfaceDiffEq/test/callbacks.jl") end
           cd(cdir)
       end
OrdinaryDiffEq
DelayDiffEq
StochasticDiffEq
Sundials
ODEInterfaceDiffEq
108.518739 seconds (223.40 M allocations: 53.189 GiB, 19.12% gc time)

julia> using DifferentialEquations

julia>
```