### PR TITLE
Remove imports

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -3,22 +3,11 @@ module DiffEqBase
 using RecipesBase, RecursiveArrayTools, Compat,
       Requires, TableTraits, IteratorInterfaceExtensions, TreeViews
 
-import Base: length, size, getindex, setindex!, show, print,
-             iterate, eltype, similar, axes
+using Roots # callbacks
 
-import Base: resize!, deleteat!
+using StaticArrays # data arrays
 
-import RecursiveArrayTools: recursivecopy!, tuples
-
-import RecursiveArrayTools: chain
-
-import Roots # callbacks
-
-import LinearAlgebra: exp, ldiv!
-
-import StaticArrays: StaticArray, SArray, Size
-
-import Statistics: mean, median
+using LinearAlgebra, Statistics
 
 # Problems
 abstract type DEProblem end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -265,7 +265,7 @@ function find_callback_time(integrator,callback,counter)
             end
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
-          Θ = prevfloat(Roots.find_zero(zero_func,(bottom_θ,top_Θ),Roots.AlefeldPotraShi(),atol = callback.abstol/100))
+          Θ = prevfloat(find_zero(zero_func,(bottom_θ,top_Θ), AlefeldPotraShi(),atol = callback.abstol/100))
           integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ))
         end
         #Θ = prevfloat(...)

--- a/src/data_array.jl
+++ b/src/data_array.jl
@@ -4,24 +4,24 @@ next(A::DEDataArray, i) = next(A.x, i)
 done(A::DEDataArray, i) = done(A.x, i)
 
 # size
-length(A::DEDataArray) = length(A.x)
-size(A::DEDataArray) = size(A.x)
+Base.length(A::DEDataArray) = length(A.x)
+Base.size(A::DEDataArray) = size(A.x)
 
 # indexing
-@inline function getindex(A::DEDataArray, I...)
+@inline function Base.getindex(A::DEDataArray, I...)
     @boundscheck checkbounds(A.x, I...)
     @inbounds return A.x[I...]
 end
-@inline function setindex!(A::DEDataArray, x, I...)
+@inline function Base.setindex!(A::DEDataArray, x, I...)
     @boundscheck checkbounds(A.x, I...)
     @inbounds A.x[I...] = x
 end
-axes(A::DEDataArray) = axes(A.x)
+Base.axes(A::DEDataArray) = axes(A.x)
 Base.LinearIndices(A::DEDataArray) = LinearIndices(A.x)
 Base.IndexStyle(::Type{<:DEDataArray}) = Base.IndexLinear()
 
 # similar data arrays
-@generated function similar(A::DEDataArray, ::Type{T}, dims::NTuple{N,Int}) where {T,N}
+@generated function Base.similar(A::DEDataArray, ::Type{T}, dims::NTuple{N,Int}) where {T,N}
     assignments = [s == :x ? :(typeof(A.x) <: StaticArray ? similar(A.x, T, Size(A.x)) : similar(A.x, T, dims)) :
                    (sq = Meta.quot(s); :(deepcopy(getfield(A, $sq))))
                    for s in fieldnames(A)]
@@ -33,7 +33,7 @@ end
 
 Recursively copy fields of `src` to `dest`.
 """
-@generated function recursivecopy!(dest::T, src::T) where {T<:DEDataArray}
+@generated function RecursiveArrayTools.recursivecopy!(dest::T, src::T) where {T<:DEDataArray}
     fields = fieldnames(src)
 
     expressions = Vector{Expr}(undef, length(fields))

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -8,8 +8,8 @@ passed to the optional third argument, the integrator advances exactly
 `dt`.
 """
 function step!(d::DEIntegrator) error("Integrator stepping is not implemented") end
-resize!(i::DEIntegrator,ii::Int) = error("resize!: method has not been implemented for the integrator")
-deleteat!(i::DEIntegrator,ii) = error("deleteat!: method has not been implemented for the integrator")
+Base.resize!(i::DEIntegrator,ii::Int) = error("resize!: method has not been implemented for the integrator")
+Base.deleteat!(i::DEIntegrator,ii) = error("deleteat!: method has not been implemented for the integrator")
 addat!(i::DEIntegrator,ii,val=zeros(length(idxs))) = error("addat!: method has not been implemented for the integrator")
 get_tmp_cache(i::DEIntegrator) = error("get_tmp_cache!: method has not been implemented for the integrator")
 user_cache(i::DEIntegrator) = error("user_cache: method has not been implemented for the integrator")
@@ -189,7 +189,7 @@ function done(integrator::DEIntegrator)
   end
   false
 end
-function iterate(integrator::DEIntegrator,state=0)
+function Base.iterate(integrator::DEIntegrator,state=0)
   done(integrator) && return nothing
   state += 1
   step!(integrator) # Iter updated in the step! header
@@ -197,7 +197,7 @@ function iterate(integrator::DEIntegrator,state=0)
   return integrator,state
 end
 
-eltype(integrator::DEIntegrator) = typeof(integrator)
+Base.eltype(integrator::DEIntegrator) = typeof(integrator)
 
 ### Other Iterators
 
@@ -205,7 +205,7 @@ struct IntegratorTuples{I}
  integrator::I
 end
 
-function iterate(tup::IntegratorTuples, state=0)
+function Base.iterate(tup::IntegratorTuples, state=0)
   done(tup.integrator) && return nothing
   step!(tup.integrator) # Iter updated in the step! header
   state += 1
@@ -213,13 +213,13 @@ function iterate(tup::IntegratorTuples, state=0)
   return (tup.integrator.u,tup.integrator.t),state
 end
 
-tuples(integrator::DEIntegrator) = IntegratorTuples(integrator)
+RecursiveArrayTools.tuples(integrator::DEIntegrator) = IntegratorTuples(integrator)
 
 struct IntegratorIntervals{I}
  integrator::I
 end
 
-function iterate(tup::IntegratorIntervals,state=0)
+function Base.iterate(tup::IntegratorIntervals,state=0)
   done(tup.integrator) && return nothing
   state += 1
   step!(tup.integrator) # Iter updated in the step! header
@@ -234,7 +234,7 @@ struct TimeChoiceIterator{T,T2}
   ts::T2
 end
 
-function iterate(iter::TimeChoiceIterator,state=1)
+function Base.iterate(iter::TimeChoiceIterator,state=1)
   state > length(iter.ts) && return nothing
   t = iter.ts[state]
   integrator = iter.integrator

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -5,7 +5,7 @@ Base.getindex(A::AbstractNoTimeSolution,i::Int) = A.u[i]
 Base.getindex(A::AbstractNoTimeSolution,I::Vararg{Int, N}) where {N} = A.u[I]
 Base.setindex!(A::AbstractNoTimeSolution, v, i::Int) = (A.u[i] = v)
 Base.setindex!(A::AbstractNoTimeSolution, v, I::Vararg{Int, N}) where {N} = (A.u[I] = v)
-size(A::AbstractNoTimeSolution) = size(A.u)
+Base.size(A::AbstractNoTimeSolution) = size(A.u)
 
 Base.summary(A::AbstractNoTimeSolution) = string(nameof(typeof(A))," with uType ",eltype(A.u))
 Base.show(io::IO, A::AbstractNoTimeSolution) = (print(io,"u: ");show(io, A.u))
@@ -44,9 +44,9 @@ function TreeViews.treelabel(io::IO,x::DiffEqBase.DESolution,
   show(io,mime,Text(Base.summary(x)))
 end
 
-tuples(sol::AbstractTimeseriesSolution) = tuple.(sol.u,sol.t)
+RecursiveArrayTools.tuples(sol::AbstractTimeseriesSolution) = tuple.(sol.u,sol.t)
 
-function iterate(sol::AbstractTimeseriesSolution,state=0)
+function Base.iterate(sol::AbstractTimeseriesSolution,state=0)
   state >= length(sol) && return nothing
   state += 1
   return (solution_new_tslocation(sol,state),state)

--- a/test/data_array_tests.jl
+++ b/test/data_array_tests.jl
@@ -1,4 +1,4 @@
-using DiffEqBase, Test
+using DiffEqBase, RecursiveArrayTools, Test
 
 mutable struct VectorType{T} <: DEDataVector{T}
     x::Vector{T}
@@ -50,10 +50,10 @@ a2 = similar(a); b2 = similar(b, (1,4)); b3 = similar(b, Float64, (1, 4))
 @test typeof(b3.x) == Matrix{Float64} && b3.f == 2.0
 
 # copy all fields of data arrays
-DiffEqBase.recursivecopy!(a2, a)
-DiffEqBase.recursivecopy!(b2, b)
+recursivecopy!(a2, a)
+recursivecopy!(b2, b)
 @test a2.x == A && vec(b2.x) == vec(B)
-DiffEqBase.recursivecopy!(b3, b)
+recursivecopy!(b3, b)
 
 # copy all fields except of field x
 a2.f = 3.0; b2.f = -1; b3.f == 0

--- a/test/high_level_solve.jl
+++ b/test/high_level_solve.jl
@@ -17,4 +17,7 @@ prob2 = DiffEqBase.get_concrete_problem(prob,nothing)
 @test typeof(prob2.u0) == Float64
 
 prob = ODEProblem((u,p,t)->u,1.0,(0,1))
-DiffEqBase.adaptive_warn(prob.u0,prob.tspan)
+@test_logs (:warn,
+            "Integer time values are incompatible with adaptive integrators. Utilize " *
+            "floating point numbers instead of integers in this case, i.e. (0.0,1.0) " *
+            "instead of (0,1).") DiffEqBase.adaptive_warn(prob.u0,prob.tspan)


### PR DESCRIPTION
Remove `import` statements and consistently specify full name of extended methods.