### PR TITLE
Add time to internalnorm and defaults

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -266,7 +266,7 @@ function find_callback_time(integrator,callback,counter)
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
           Θ = prevfloat(find_zero(zero_func, (bottom_θ,top_Θ), Roots.AlefeldPotraShi(), atol = callback.abstol/100))
-          integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ))
+          integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ),integrator.t+integrator.dt*Θ)
         end
         #Θ = prevfloat(...)
         # prevfloat guerentees that the new time is either 1 floating point

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -177,7 +177,7 @@ end
     @views previous_condition = callback.condition(integrator.uprev[callback.idxs],integrator.tprev,integrator)
   end
 
-  if integrator.event_last_time == counter && ODE_DEFAULT_NORM(previous_condition) < 100ODE_DEFAULT_NORM(integrator.last_event_error)
+  if integrator.event_last_time == counter && ODE_DEFAULT_NORM(previous_condition,integrator.t) < 100ODE_DEFAULT_NORM(integrator.last_event_error,integrator.t)
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -1,10 +1,10 @@
 @inline UNITLESS_ABS2(x) = Real(abs2(x)/(typeof(x)(one(x))*typeof(x)(one(x))))
-@inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex}) = abs(u)
-@inline ODE_DEFAULT_NORM(u::Array{T}) where T<:Union{AbstractFloat,Complex} =
+@inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex},t) = abs(u)
+@inline ODE_DEFAULT_NORM(u::Array{T},t) where T<:Union{AbstractFloat,Complex} =
                                          @fastmath sqrt(sum(abs2,u) / length(u))
-@inline ODE_DEFAULT_NORM(u::AbstractArray) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
-@inline ODE_DEFAULT_NORM(u::AbstractArray{T,N}) where {T<:AbstractArray,N} = sqrt(sum(ODE_DEFAULT_NORM,u) / length(u))
-@inline ODE_DEFAULT_NORM(u) = norm(u)
+@inline ODE_DEFAULT_NORM(u::AbstractArray,t) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
+@inline ODE_DEFAULT_NORM(u::AbstractArray{T,N},t) where {T<:AbstractArray,N} = sqrt(sum(ODE_DEFAULT_NORM,u) / length(u))
+@inline ODE_DEFAULT_NORM(u,t) = norm(u)
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u,p,t) = false
 @inline ODE_DEFAULT_PROG_MESSAGE(dt,u,p,t) =
            "dt="*string(dt)*"\nt="*string(t)*"\nmax u="*string(maximum(abs.(u)))

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -1,10 +1,19 @@
 @inline UNITLESS_ABS2(x) = Real(abs2(x)/(typeof(x)(one(x))*typeof(x)(one(x))))
+
+@inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex}) = abs(u)
+@inline ODE_DEFAULT_NORM(u::Array{T}) where T<:Union{AbstractFloat,Complex} =
+                                         @fastmath sqrt(sum(abs2,u) / length(u))
+@inline ODE_DEFAULT_NORM(u::AbstractArray) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
+@inline ODE_DEFAULT_NORM(u::AbstractArray{T,N}) where {T<:AbstractArray,N} = sqrt(sum(ODE_DEFAULT_NORM,u) / length(u))
+@inline ODE_DEFAULT_NORM(u) = norm(u)
+
 @inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex},t) = abs(u)
 @inline ODE_DEFAULT_NORM(u::Array{T},t) where T<:Union{AbstractFloat,Complex} =
                                          @fastmath sqrt(sum(abs2,u) / length(u))
 @inline ODE_DEFAULT_NORM(u::AbstractArray,t) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
 @inline ODE_DEFAULT_NORM(u::AbstractArray{T,N},t) where {T<:AbstractArray,N} = sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip(u,t)) / length(u))
 @inline ODE_DEFAULT_NORM(u,t) = norm(u)
+
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u,p,t) = false
 @inline ODE_DEFAULT_PROG_MESSAGE(dt,u,p,t) =
            "dt="*string(dt)*"\nt="*string(t)*"\nmax u="*string(maximum(abs.(u)))

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -3,7 +3,7 @@
 @inline ODE_DEFAULT_NORM(u::Array{T},t) where T<:Union{AbstractFloat,Complex} =
                                          @fastmath sqrt(sum(abs2,u) / length(u))
 @inline ODE_DEFAULT_NORM(u::AbstractArray,t) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
-@inline ODE_DEFAULT_NORM(u::AbstractArray{T,N},t) where {T<:AbstractArray,N} = sqrt(sum(ODE_DEFAULT_NORM,u) / length(u))
+@inline ODE_DEFAULT_NORM(u::AbstractArray{T,N},t) where {T<:AbstractArray,N} = sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip(u,t)) / length(u))
 @inline ODE_DEFAULT_NORM(u,t) = norm(u)
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u,p,t) = false
 @inline ODE_DEFAULT_PROG_MESSAGE(dt,u,p,t) =

--- a/src/init.jl
+++ b/src/init.jl
@@ -4,13 +4,23 @@ function __init__()
   end
 
   @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N}) where {N}
+    # Support adaptive with non-dual time
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
     end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:ForwardDiff.Dual,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::Array{<:ForwardDiff.Dual,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(ForwardDiff.value(x) for x in u)) / length(u))
     end
-    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual) = abs(ForwardDiff.value(u))
+    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,t) = abs(ForwardDiff.value(u))
+
+    # When time is dual, it shouldn't drop the duals for adaptivity
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N},t::ForwardDiff.Dual) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(x for x in u)) / length(u))
+    end
+    @inline function ODE_DEFAULT_NORM(u::Array{<:ForwardDiff.Dual,N},t::ForwardDiff.Dual) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(x for x in u)) / length(u))
+    end
+    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,t::ForwardDiff.Dual) = abs(u)
 
     # Type piracy. Should upstream
     Base.nextfloat(d::ForwardDiff.Dual{T,V,N}) where {T,V,N} = ForwardDiff.Dual{T}(nextfloat(d.value), d.partials)
@@ -18,39 +28,55 @@ function __init__()
   end
 
   @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Measurements.Measurement,N}) where {N}
+    # Support adaptive steps should be errorless
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Measurements.Measurement,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(Measurements.value(x) for x in u)) / length(u))
     end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:Measurements.Measurement,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::Array{<:Measurements.Measurement,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(Measurements.value(x) for x in u)) / length(u))
     end
-    @inline ODE_DEFAULT_NORM(u::Measurements.Measurement) = abs(Measurements.value(u))
+    @inline ODE_DEFAULT_NORM(u::Measurements.Measurement,t) = abs(Measurements.value(u))
   end
 
   @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" begin
+    # Support adaptive errors should be errorless for exponentiation
     value(x::Unitful.Quantity) = x.val
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Unitful.Quantity,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Unitful.Quantity,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
     end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:Unitful.Quantity,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::Array{<:Unitful.Quantity,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
     end
-    @inline ODE_DEFAULT_NORM(u::Unitful.Quantity) = abs(value(u))
+    @inline ODE_DEFAULT_NORM(u::Unitful.Quantity,t) = abs(value(u))
   end
 
   @require Flux="587475ba-b771-5e3f-ad9e-33799f191a9c" begin
     value(x::Flux.Tracker.TrackedReal)  = x.data
     value(x::Flux.Tracker.TrackedArray) = x.data
-    @inline function ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedArray) where {N}
+
+    # Support adaptive with non-tracked time
+    @inline function ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedArray,t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
     end
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Flux.Tracker.TrackedReal,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Flux.Tracker.TrackedReal,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
     end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:Flux.Tracker.TrackedReal,N}) where {N}
+    @inline function ODE_DEFAULT_NORM(u::Array{<:Flux.Tracker.TrackedReal,N},t) where {N}
       sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
     end
-    @inline ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedReal) = abs(value(u))
+    @inline ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedReal,t) = abs(value(u))
+
+    # Support TrackedReal time, don't drop tracking on the adaptivity there
+    @inline function ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedArray,t::Flux.Tracker.TrackedReal) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
+    end
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Flux.Tracker.TrackedReal,N},t::Flux.Tracker.TrackedReal) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
+    end
+    @inline function ODE_DEFAULT_NORM(u::Array{<:Flux.Tracker.TrackedReal,N},t::Flux.Tracker.TrackedReal) where {N}
+      sqrt(sum(ODE_DEFAULT_NORM,(value(x) for x in u)) / length(u))
+    end
+    @inline ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedReal,t::Flux.Tracker.TrackedReal) = abs(value(u))
   end
 
 end


### PR DESCRIPTION
This allows proper handling of dual number time, along with allowing the user to do crazy things like change the adaptivity to be looser as time progresses