### PR TITLE
add syms field for DiscreteFunctions

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -44,9 +44,10 @@ struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{ii
 end
 
 abstract type AbstractDiscreteFunction{iip} <: AbstractDiffEqFunction{iip} end
-struct DiscreteFunction{iip,F,Ta} <: AbstractDiscreteFunction{iip}
+struct DiscreteFunction{iip,F,Ta,S} <: AbstractDiscreteFunction{iip}
   f::F
   analytic::Ta
+  syms::S
 end
 
 abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip} end
@@ -243,14 +244,14 @@ DynamicalODEFunction{iip,RECOMPILE_BY_DEFAULT}(ODEFunction{iip}(f1), ODEFunction
 DynamicalODEFunction(f::DynamicalODEFunction; kwargs...) = f
 
 function DiscreteFunction{iip,true}(f;
-                 analytic=nothing) where iip
-                 DiscreteFunction{iip,typeof(f),typeof(analytic)}(
-                 f,analytic)
+                 analytic=nothing, syms=nothing) where iip
+                 DiscreteFunction{iip,typeof(f),typeof(analytic),typeof(syms)}(
+                 f,analytic,syms)
 end
 function DiscreteFunction{iip,false}(f;
-                 analytic=nothing) where iip
-                 DiscreteFunction{iip,Any,Any}(
-                 f,analytic)
+                 analytic=nothing, syms=nothing) where iip
+                 DiscreteFunction{iip,Any,Any,Any}(
+                 f,analytic,syms)
 end
 DiscreteFunction(f; kwargs...) = DiscreteFunction{isinplace(f, 4),RECOMPILE_BY_DEFAULT}(f; kwargs...)
 DiscreteFunction(f::DiscreteFunction; kwargs...) = f
@@ -580,7 +581,12 @@ function Base.convert(::Type{DiscreteFunction},f)
   else
     analytic = nothing
   end
-  DiscreteFunction(f;analytic=analytic)
+  if __has_syms(f)
+    syms = f.syms
+  else
+    syms = nothing
+  end
+  DiscreteFunction(f;analytic=analytic,syms=syms)
 end
 function Base.convert(::Type{DiscreteFunction{iip}},f) where iip
   if __has_analytic(f)
@@ -588,7 +594,12 @@ function Base.convert(::Type{DiscreteFunction{iip}},f) where iip
   else
     analytic = nothing
   end
-  DiscreteFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic)
+  if __has_syms(f)
+    syms = f.syms
+  else
+    syms = nothing
+  end
+  DiscreteFunction{iip,RECOMPILE_BY_DEFAULT}(f;analytic=analytic,syms=syms)
 end
 
 DAEFunction{iip}(f::T) where {iip,T} = return T<:DAEFunction ? f : convert(DAEFunction{iip},f)


### PR DESCRIPTION
Currently DiffEqBiological can get syms to appear in plot legends for ODEs and SDEs, but not for jump problems. The underlying issue seems to be that `DiscreteFunction` didn't have fields to store the syms. This adds such fields in. Adding a reaction_network overload for `DiscreteProblem`s in DiffEqBiological will then allow us to get syms from reaction networks.

(I realize DiffEqBase is supposed to be updated infrequently, so if this is not worth adding in feel free to close. That said, I would really like it if I could get syms for jumps to allow auto labels in plot legends...)