### PR TITLE
Fix type instability in build_solution

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -21,8 +21,7 @@ function build_solution(
         dense=false,dense_errors=dense,
         calculate_error = true,
         k=[],
-        du=[],
-        interp = !isempty(du) ? HermiteInterpolation(t,u,du) : LinearInterpolation(t,u),
+        interp = LinearInterpolation(t,u),
         retcode = :Default, destats=DEStats(), kwargs...)
 
   T = eltype(eltype(u))


### PR DESCRIPTION
Currently the type of `sol(ode_prob, alg)` can not be inferred for algorithms in ODEInterfaceDiffEq and LSODA. Here's a (slightly complicated) example:
```julia
using ParameterizedFunctions, DiffEqBase
rober = @ode_def Rober begin
  dy₁ = -k₁*y₁+k₃*y₂*y₃
  dy₂ =  k₁*y₁-k₂*y₂^2-k₃*y₂*y₃
  dy₃ =  k₂*y₂^2
end k₁ k₂ k₃
prob = ODEProblem(rober,[1.0;0.0;0.0],(0.0,1e11),(0.04,3e7,1e4))

using ODEInterfaceDiffEq
@code_warntype solve(prob,radau())

using LSODA
@code_warntype solve(prob,lsoda())
```