### PR TITLE
API Documentation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ StaticArrays 0.8.3
 TableTraits 0.3.0
 TreeViews
 Roots
+DocStringExtensions

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,15 @@
+using Documenter
+using DiffEqBase
+
+makedocs(
+    sitename = "DiffEqBase",
+    format = :html,
+    modules = [DiffEqBase]
+)
+
+# Documenter can also automatically deploy documentation to gh-pages.
+# See "Hosting Documentation" and deploydocs() in the Documenter manual
+# for more information.
+#=deploydocs(
+    repo = "<repository url>"
+)=#

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,13 @@ using DiffEqBase
 makedocs(
     sitename = "DiffEqBase",
     format = :html,
-    modules = [DiffEqBase]
+    modules = [DiffEqBase],
+    pages = [
+        "index.md",
+        "API" => [
+            "Overview" => "api/overview.md",
+        ],
+    ],
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(
         "index.md",
         "API" => [
             "Overview" => "api/overview.md",
+            "api/functions.md",
             "api/problems.md",
         ],
     ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(
         "index.md",
         "API" => [
             "Overview" => "api/overview.md",
+            "api/problems.md",
         ],
     ],
 )

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -6,27 +6,27 @@ Functions for the different categories of differential equations are
 defined by subtypes of `AbstractDiffEqFunction`:
 
 ```@docs
-AbstractDiffEqFunction
-AbstractDiscreteFunction
+DiffEqBase.AbstractDiffEqFunction
+DiffEqBase.AbstractDiscreteFunction
 DiscreteFunction
-AbstractODEFunction
+DiffEqBase.AbstractODEFunction
 ODEFunction
 DynamicalODEFunction
 SplitFunction
-AbstractSDEFunction
+DiffEqBase.AbstractSDEFunction
 SDEFunction
 SplitSDEFunction
-AbstractRODEFunction
+DiffEqBase.AbstractRODEFunction
 RODEFunction
-AbstractDDEFunction
+DiffEqBase.AbstractDDEFunction
 DDEFunction
-AbstractDAEFunction
+DiffEqBase.AbstractDAEFunction
 DAEFunction
 ```
 
 ## Utilities
 
-```@doc
+```@docs
 has_analytic
 has_jac
 has_tgrad

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -1,4 +1,4 @@
-# Functions
+# DE functions
 
 ## Function types
 
@@ -22,4 +22,16 @@ AbstractDDEFunction
 DDEFunction
 AbstractDAEFunction
 DAEFunction
+```
+
+## Utilities
+
+```@doc
+has_analytic
+has_jac
+has_tgrad
+has_invW
+has_invW_t
+has_paramjac
+has_syms
 ```

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -1,0 +1,25 @@
+# Functions
+
+## Function types
+
+Functions for the different categories of differential equations are
+defined by subtypes of `AbstractDiffEqFunction`:
+
+```@docs
+AbstractDiffEqFunction
+AbstractDiscreteFunction
+DiscreteFunction
+AbstractODEFunction
+ODEFunction
+DynamicalODEFunction
+SplitFunction
+AbstractSDEFunction
+SDEFunction
+SplitSDEFunction
+AbstractRODEFunction
+RODEFunction
+AbstractDDEFunction
+DDEFunction
+AbstractDAEFunction
+DAEFunction
+```

--- a/docs/src/api/overview.md
+++ b/docs/src/api/overview.md
@@ -1,0 +1,16 @@
+# API Overviews
+
+
+```@index
+```
+
+
+## Type parameters
+
+The following are common type parameters that appear throughout the package:
+
+* `uType` - Element type of the state vector of a DE function or problem. Typically a subtype of `Real`.
+* `tType` - Type of time variable used in a DE function or problem. Typically a subtype of `Real`.
+* `isinplace` - Boolean value which indicates whether a DE function operates in-place (sets values of an array passed as its first argument rather than returning a new array).
+  Also appears as `iip`.
+* `ND`  - TODO

--- a/docs/src/api/overview.md
+++ b/docs/src/api/overview.md
@@ -1,10 +1,6 @@
 # API Overviews
 
 
-```@index
-```
-
-
 ## Type parameters
 
 The following are common type parameters that appear throughout the package:
@@ -14,3 +10,9 @@ The following are common type parameters that appear throughout the package:
 * `isinplace` - Boolean value which indicates whether a DE function operates in-place (sets values of an array passed as its first argument rather than returning a new array).
   Also appears as `iip`.
 * `ND`  - TODO
+
+
+## Index
+
+```@index
+```

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -22,6 +22,20 @@ DiscreteProblem
 
 ```@docs
 AbstractODEProblem
+ODEProblem
+```
+
+#### Subtypes
+
+TODO: document `problem_type` field.
+
+```@docs
+StandardODEProblem
+AbstractDynamicalODEProblem
+DynamicalODEProblem
+SecondOrderODEProblem
+AbstractSplitODEProblem
+SplitODEProblem
 ```
 
 ### Steady state problems

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -1,0 +1,60 @@
+# Problems
+
+
+TODO:
+* How do optional parameters (`p=nothing`) work?
+
+
+## Problem types
+
+```@docs
+DEProblem
+```
+
+### Discrete problems
+
+```@docs
+AbstractDiscreteProblem
+```
+
+### ODE problems
+
+```@docs
+AbstractODEProblem
+```
+
+### Steady state problems
+
+```@docs
+AbstractSteadyStateProblem
+```
+
+### SDE problems
+
+```@docs
+AbstractSDEProblem
+```
+
+### RODE problems
+
+```@docs
+AbstractRODEProblem
+```
+
+### DDE problems
+
+```@docs
+AbstractDDEProblem
+```
+
+### DAE problems
+
+```@docs
+AbstractDAEProblem
+```
+
+### Jump problems
+
+```@docs
+AbstractJumpProblem
+```

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -4,15 +4,6 @@
 TODO:
 * How do optional parameters (`p=nothing`) work?
 
-
-## Functions
-
-```@docs
-isinplace
-is_diagonal_noise
-promote_tspan
-```
-
 ## Problem types
 
 ```@docs
@@ -97,4 +88,13 @@ DAEProblem
 
 ```@docs
 AbstractJumpProblem
+```
+
+
+## Utilities
+
+```@docs
+isinplace
+is_diagonal_noise
+promote_tspan
 ```

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -42,6 +42,7 @@ SplitODEProblem
 
 ```@docs
 AbstractSteadyStateProblem
+SteadyStateProblem
 ```
 
 ### SDE problems

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -15,6 +15,7 @@ DEProblem
 
 ```@docs
 AbstractDiscreteProblem
+DiscreteProblem
 ```
 
 ### ODE problems

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -45,28 +45,44 @@ AbstractSteadyStateProblem
 SteadyStateProblem
 ```
 
+### BVP problems
+
+```@docs
+AbstractBVPProblem
+StandardBVProblem
+BVProblem
+TwoPointBVProblem
+```
+
 ### SDE problems
 
 ```@docs
 AbstractSDEProblem
+StandardSDEProblem
+SDEProblem
+AbstractSplitSDEProblem
+SplitSDEProblem
 ```
 
 ### RODE problems
 
 ```@docs
 AbstractRODEProblem
+RODEProblem
 ```
 
 ### DDE problems
 
 ```@docs
 AbstractDDEProblem
+DDEProblem
 ```
 
 ### DAE problems
 
 ```@docs
 AbstractDAEProblem
+DAEProblem
 ```
 
 ### Jump problems

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -7,20 +7,20 @@ TODO:
 ## Problem types
 
 ```@docs
-DEProblem
+DiffEqBase.DEProblem
 ```
 
 ### Discrete problems
 
 ```@docs
-AbstractDiscreteProblem
+DiffEqBase.AbstractDiscreteProblem
 DiscreteProblem
 ```
 
 ### ODE problems
 
 ```@docs
-AbstractODEProblem
+DiffEqBase.AbstractODEProblem
 ODEProblem
 ```
 
@@ -29,26 +29,26 @@ ODEProblem
 TODO: document `problem_type` field.
 
 ```@docs
-StandardODEProblem
-AbstractDynamicalODEProblem
+DiffEqBase.StandardODEProblem
+DiffEqBase.AbstractDynamicalODEProblem
 DynamicalODEProblem
 SecondOrderODEProblem
-AbstractSplitODEProblem
+DiffEqBase.AbstractSplitODEProblem
 SplitODEProblem
 ```
 
 ### Steady state problems
 
 ```@docs
-AbstractSteadyStateProblem
+DiffEqBase.AbstractSteadyStateProblem
 SteadyStateProblem
 ```
 
-### BVP problems
+### Boundary value problems
 
 ```@docs
-AbstractBVPProblem
-StandardBVProblem
+DiffEqBase.AbstractBVProblem
+DiffEqBase.StandardBVProblem
 BVProblem
 TwoPointBVProblem
 ```
@@ -56,38 +56,38 @@ TwoPointBVProblem
 ### SDE problems
 
 ```@docs
-AbstractSDEProblem
-StandardSDEProblem
+DiffEqBase.AbstractSDEProblem
+DiffEqBase.StandardSDEProblem
 SDEProblem
-AbstractSplitSDEProblem
+DiffEqBase.AbstractSplitSDEProblem
 SplitSDEProblem
 ```
 
 ### RODE problems
 
 ```@docs
-AbstractRODEProblem
+DiffEqBase.AbstractRODEProblem
 RODEProblem
 ```
 
 ### DDE problems
 
 ```@docs
-AbstractDDEProblem
+DiffEqBase.AbstractDDEProblem
 DDEProblem
 ```
 
 ### DAE problems
 
 ```@docs
-AbstractDAEProblem
+DiffEqBase.AbstractDAEProblem
 DAEProblem
 ```
 
 ### Jump problems
 
 ```@docs
-AbstractJumpProblem
+DiffEqBase.AbstractJumpProblem
 ```
 
 
@@ -95,6 +95,6 @@ AbstractJumpProblem
 
 ```@docs
 isinplace
-is_diagonal_noise
-promote_tspan
+DiffEqBase.is_diagonal_noise
+DiffEqBase.promote_tspan
 ```

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -5,6 +5,14 @@ TODO:
 * How do optional parameters (`p=nothing`) work?
 
 
+## Functions
+
+```@docs
+isinplace
+is_diagonal_noise
+promote_tspan
+```
+
 ## Problem types
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+# DiffEqBase.jl
+
+Documentation for DiffEqBase.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,5 @@
 # DiffEqBase.jl
 
 Documentation for DiffEqBase.jl
+
+This should be merged into `DiffEqDocs` or `DiffEqDevDocs` eventually.

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -344,6 +344,8 @@ abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T} end
 
 """
     abstract type AbstractDiffEqFunction{iip} <: Function
+
+Base for types defining differential equation functions.
 """
 abstract type AbstractDiffEqFunction{iip} <: Function end
 

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -10,79 +10,246 @@ using StaticArrays # data arrays
 using LinearAlgebra, Statistics
 
 # Problems
+"""
+    abstract type DEProblem
+"""
 abstract type DEProblem end
+
+"""
+    abstract type DEElement
+"""
 abstract type DEElement end
+
+"""
+    abstract type DESensitivity
+"""
 abstract type DESensitivity end
 
+"""
+    abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem
+"""
 abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem end
 
+"""
+    abstract type AbstractNoiseProblem <: DEProblem
+"""
 abstract type AbstractNoiseProblem <: DEProblem end
 
+"""
+    abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem
+"""
 abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem end
+
+"""
+    abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
+                          AbstractODEProblem{uType,tType,isinplace}
+"""
 abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
                       AbstractODEProblem{uType,tType,isinplace} end
+
+"""
+    abstract type AbstractAnalyticalProblem{uType,tType,isinplace} <:
+                          AbstractODEProblem{uType,tType,isinplace}
+"""
 abstract type AbstractAnalyticalProblem{uType,tType,isinplace} <:
                       AbstractODEProblem{uType,tType,isinplace} end
 
+"""
+    abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem
+"""
 abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem end
 
+"""
+    abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
+                          AbstractRODEProblem{uType,tType,isinplace,ND}
+"""
 abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
                       AbstractRODEProblem{uType,tType,isinplace,ND} end
 
+"""
+    abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem
+"""
 abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem end
 
+"""
+    abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem
+"""
 abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem end
+
+"""
+    abstract type AbstractConstantLagDDEProblem{uType,tType,lType,isinplace} <:
+                          AbstractDDEProblem{uType,tType,lType,isinplace}
+"""
 abstract type AbstractConstantLagDDEProblem{uType,tType,lType,isinplace} <:
                       AbstractDDEProblem{uType,tType,lType,isinplace} end
 
+"""
+    abstract type AbstractSecondOrderODEProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace}
+"""
 abstract type AbstractSecondOrderODEProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace} end
 
+"""
+    abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace}
+"""
 abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace} end
 
+"""
+    abstract type AbstractJumpProblem{P,J} <: DiffEqBase
+"""
 abstract type AbstractJumpProblem{P,J} <: DiffEqBase.DEProblem end
 
 # Algorithms
+"""
+    abstract type DEAlgorithm
+"""
 abstract type DEAlgorithm end
+
+"""
+    abstract type AbstractSteadyStateAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractSteadyStateAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractODEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractODEAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractSecondOrderODEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractSecondOrderODEAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractRODEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractRODEAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractSDEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractSDEAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractDAEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractDAEAlgorithm <: DEAlgorithm end
+
+"""
+    abstract type AbstractDDEAlgorithm <: DEAlgorithm
+"""
 abstract type AbstractDDEAlgorithm <: DEAlgorithm end
 
 # Monte Carlo Simulations
+"""
+    abstract type AbstractMonteCarloProblem <: DEProblem
+"""
 abstract type AbstractMonteCarloProblem <: DEProblem end
+
+"""
+    abstract type AbstractMonteCarloEstimator <: DEProblem
+"""
 abstract type AbstractMonteCarloEstimator <: DEProblem end
 
 export MonteCarloProblem
 export MonteCarloSolution, MonteCarloTestSolution, MonteCarloSummary
 
+"""
+    abstract type AbstractDiffEqInterpolation <: Function
+"""
 abstract type AbstractDiffEqInterpolation <: Function end
+
+"""
+    abstract type AbstractDEOptions
+"""
 abstract type AbstractDEOptions end
+
+"""
+    abstract type DECache
+"""
 abstract type DECache end
+
+"""
+    abstract type DECallback
+"""
 abstract type DECallback end
+
+"""
+    abstract type AbstractContinuousCallback <: DECallback
+"""
 abstract type AbstractContinuousCallback <: DECallback end
+
+"""
+    abstract type AbstractDiscreteCallback <: DECallback
+"""
 abstract type AbstractDiscreteCallback <: DECallback end
 
+"""
+    abstract type DEDataArray{T,N} <: AbstractArray{T,N}
+"""
 abstract type DEDataArray{T,N} <: AbstractArray{T,N} end
 const DEDataVector{T} = DEDataArray{T,1}
 const DEDataMatrix{T} = DEDataArray{T,2}
 
 # Integrators
+"""
+    abstract type DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractSteadyStateIntegrator{Alg, IIP, U} <: DEIntegrator{Alg, IIP, U, Nothing}
+"""
 abstract type AbstractSteadyStateIntegrator{Alg, IIP, U} <: DEIntegrator{Alg, IIP, U, Nothing} end
+
+"""
+    abstract type AbstractODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractSecondOrderODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractSecondOrderODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractRODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractRODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractSDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractSDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractDDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractDDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
+
+"""
+    abstract type AbstractDAEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+"""
 abstract type AbstractDAEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 # Solutions
+"""
+    abstract type AbstractNoTimeSolution{T,N} <: AbstractArray{T,N}
+"""
 abstract type AbstractNoTimeSolution{T,N} <: AbstractArray{T,N} end
+
+"""
+    abstract type AbstractTimeseriesSolution{T,N} <: AbstractDiffEqArray{T,N}
+"""
 abstract type AbstractTimeseriesSolution{T,N} <: AbstractDiffEqArray{T,N} end
+
+"""
+    abstract type AbstractMonteCarloSolution{T,N} <: AbstractVectorOfArray{T,N}
+"""
 abstract type AbstractMonteCarloSolution{T,N} <: AbstractVectorOfArray{T,N} end
+
+"""
+    abstract type AbstractNoiseProcess{T,N,isinplace} <: AbstractDiffEqArray{T,N}
+"""
 abstract type AbstractNoiseProcess{T,N,isinplace} <: AbstractDiffEqArray{T,N} end
 
 const DESolution = Union{AbstractTimeseriesSolution,
@@ -90,23 +257,77 @@ const DESolution = Union{AbstractTimeseriesSolution,
                          AbstractMonteCarloSolution,
                          AbstractNoiseProcess}
 export DESolution
+
+"""
+    abstract type AbstractSteadyStateSolution{T,N} <: AbstractNoTimeSolution{T,N}
+"""
 abstract type AbstractSteadyStateSolution{T,N} <: AbstractNoTimeSolution{T,N} end
+
+"""
+    abstract type AbstractAnalyticalSolution{T,N} <: AbstractTimeseriesSolution{T,N}
+"""
 abstract type AbstractAnalyticalSolution{T,N} <: AbstractTimeseriesSolution{T,N} end
+
+"""
+    abstract type AbstractODESolution{T,N} <: AbstractTimeseriesSolution{T,N}
+"""
 abstract type AbstractODESolution{T,N} <: AbstractTimeseriesSolution{T,N} end
 
 # Needed for plot recipes
+"""
+    abstract type AbstractDDESolution{T,N} <: AbstractODESolution{T,N}
+"""
 abstract type AbstractDDESolution{T,N} <: AbstractODESolution{T,N} end
+
+"""
+    abstract type AbstractRODESolution{T,N} <: AbstractODESolution{T,N}
+"""
 abstract type AbstractRODESolution{T,N} <: AbstractODESolution{T,N} end
+
+"""
+    abstract type AbstractDAESolution{T,N} <: AbstractODESolution{T,N}
+"""
 abstract type AbstractDAESolution{T,N} <: AbstractODESolution{T,N} end
+
+"""
+    abstract type AbstractSensitivitySolution{T,N}
+"""
 abstract type AbstractSensitivitySolution{T,N} end
 
 # Misc
+"""
+    abstract type Tableau
+"""
 abstract type Tableau end
+
+"""
+    abstract type ODERKTableau <: Tableau
+"""
 abstract type ODERKTableau <: Tableau end
+
+"""
+    abstract type DECostFunction
+"""
 abstract type DECostFunction end
+
+"""
+    abstract type AbstractDiffEqOperator{T}
+"""
 abstract type AbstractDiffEqOperator{T} end
+
+"""
+    abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T}
+"""
 abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T} end
+
+"""
+    abstract type AbstractDiffEqFunction{iip} <: Function
+"""
 abstract type AbstractDiffEqFunction{iip} <: Function end
+
+"""
+    abstract type AbstractReactionNetwork <: Function
+"""
 abstract type AbstractReactionNetwork <: Function end
 
 include("destats.jl")
@@ -147,8 +368,14 @@ include("alg_traits.jl")
 include("remake.jl")
 include("init.jl")
 
+"""
+    abstract type AbstractParameterizedFunction{iip} <: AbstractODEFunction{iip}
+"""
 abstract type AbstractParameterizedFunction{iip} <: AbstractODEFunction{iip} end
 
+"""
+    struct ConvergenceSetup{P,C}
+"""
 struct ConvergenceSetup{P,C}
     probs::P
     convergence_axis::C

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -12,6 +12,10 @@ using LinearAlgebra, Statistics
 # Problems
 """
     abstract type DEProblem
+
+Base type for all DifferentialEquations.jl problems. Concrete subtypes of
+`DEProblem` contain the necessary information to fully define a differential
+equation of the corresponding type.
 """
 abstract type DEProblem end
 
@@ -27,6 +31,8 @@ abstract type DESensitivity end
 
 """
     abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem
+
+Base for types which define steady state problems for ODE systems.
 """
 abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem end
 
@@ -37,12 +43,16 @@ abstract type AbstractNoiseProblem <: DEProblem end
 
 """
     abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem
+
+Base for types which define ODE problems.
 """
 abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem end
 
 """
     abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
                           AbstractODEProblem{uType,tType,isinplace}
+
+Base for types which define discrete problems.
 """
 abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
                       AbstractODEProblem{uType,tType,isinplace} end
@@ -56,23 +66,31 @@ abstract type AbstractAnalyticalProblem{uType,tType,isinplace} <:
 
 """
     abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem
+
+Base for types which define RODE problems.
 """
 abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem end
 
 """
     abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
                           AbstractRODEProblem{uType,tType,isinplace,ND}
+
+Base for types which define SDE problems.
 """
 abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
                       AbstractRODEProblem{uType,tType,isinplace,ND} end
 
 """
     abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem
+
+Base for types which define DAE problems.
 """
 abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem end
 
 """
     abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem
+
+Base for types which define DDE problems.
 """
 abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem end
 
@@ -90,11 +108,15 @@ abstract type AbstractSecondOrderODEProblem{uType,tType,isinplace} <: AbstractOD
 
 """
     abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace}
+
+Base for types which define BVP problems.
 """
 abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace} end
 
 """
     abstract type AbstractJumpProblem{P,J} <: DiffEqBase
+
+Base for types which define jump problems.
 """
 abstract type AbstractJumpProblem{P,J} <: DiffEqBase.DEProblem end
 

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -9,9 +9,11 @@ using StaticArrays # data arrays
 
 using LinearAlgebra, Statistics
 
+using DocStringExtensions
+
 # Problems
 """
-    abstract type DEProblem
+$(TYPEDEF)
 
 Base type for all DifferentialEquations.jl problems. Concrete subtypes of
 `DEProblem` contain the necessary information to fully define a differential
@@ -20,37 +22,36 @@ equation of the corresponding type.
 abstract type DEProblem end
 
 """
-    abstract type DEElement
+$(TYPEDEF)
 """
 abstract type DEElement end
 
 """
-    abstract type DESensitivity
+$(TYPEDEF)
 """
 abstract type DESensitivity end
 
 """
-    abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem
+$(TYPEDEF)
 
 Base for types which define steady state problems for ODE systems.
 """
 abstract type AbstractSteadyStateProblem{uType,isinplace} <: DEProblem end
 
 """
-    abstract type AbstractNoiseProblem <: DEProblem
+$(TYPEDEF)
 """
 abstract type AbstractNoiseProblem <: DEProblem end
 
 """
-    abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem
+$(TYPEDEF)
 
 Base for types which define ODE problems.
 """
 abstract type AbstractODEProblem{uType,tType,isinplace} <: DEProblem end
 
 """
-    abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
-                          AbstractODEProblem{uType,tType,isinplace}
+$(TYPEDEF)
 
 Base for types which define discrete problems.
 """
@@ -58,22 +59,20 @@ abstract type AbstractDiscreteProblem{uType,tType,isinplace} <:
                       AbstractODEProblem{uType,tType,isinplace} end
 
 """
-    abstract type AbstractAnalyticalProblem{uType,tType,isinplace} <:
-                          AbstractODEProblem{uType,tType,isinplace}
+$(TYPEDEF)
 """
 abstract type AbstractAnalyticalProblem{uType,tType,isinplace} <:
                       AbstractODEProblem{uType,tType,isinplace} end
 
 """
-    abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem
+$(TYPEDEF)
 
 Base for types which define RODE problems.
 """
 abstract type AbstractRODEProblem{uType,tType,isinplace,ND} <: DEProblem end
 
 """
-    abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
-                          AbstractRODEProblem{uType,tType,isinplace,ND}
+$(TYPEDEF)
 
 Base for types which define SDE problems.
 """
@@ -81,40 +80,39 @@ abstract type AbstractSDEProblem{uType,tType,isinplace,ND} <:
                       AbstractRODEProblem{uType,tType,isinplace,ND} end
 
 """
-    abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem
+$(TYPEDEF)
 
 Base for types which define DAE problems.
 """
 abstract type AbstractDAEProblem{uType,duType,tType,isinplace} <: DEProblem end
 
 """
-    abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem
+$(TYPEDEF)
 
 Base for types which define DDE problems.
 """
 abstract type AbstractDDEProblem{uType,tType,lType,isinplace} <: DEProblem end
 
 """
-    abstract type AbstractConstantLagDDEProblem{uType,tType,lType,isinplace} <:
-                          AbstractDDEProblem{uType,tType,lType,isinplace}
+$(TYPEDEF)
 """
 abstract type AbstractConstantLagDDEProblem{uType,tType,lType,isinplace} <:
                       AbstractDDEProblem{uType,tType,lType,isinplace} end
 
 """
-    abstract type AbstractSecondOrderODEProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace}
+$(TYPEDEF)
 """
 abstract type AbstractSecondOrderODEProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace} end
 
 """
-    abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace}
+$(TYPEDEF)
 
 Base for types which define BVP problems.
 """
 abstract type AbstractBVProblem{uType,tType,isinplace} <: AbstractODEProblem{uType,tType,isinplace} end
 
 """
-    abstract type AbstractJumpProblem{P,J} <: DiffEqBase
+$(TYPEDEF)
 
 Base for types which define jump problems.
 """
@@ -122,53 +120,53 @@ abstract type AbstractJumpProblem{P,J} <: DiffEqBase.DEProblem end
 
 # Algorithms
 """
-    abstract type DEAlgorithm
+$(TYPEDEF)
 """
 abstract type DEAlgorithm end
 
 """
-    abstract type AbstractSteadyStateAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractSteadyStateAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractODEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractODEAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractSecondOrderODEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractSecondOrderODEAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractRODEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractRODEAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractSDEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractSDEAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractDAEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractDAEAlgorithm <: DEAlgorithm end
 
 """
-    abstract type AbstractDDEAlgorithm <: DEAlgorithm
+$(TYPEDEF)
 """
 abstract type AbstractDDEAlgorithm <: DEAlgorithm end
 
 # Monte Carlo Simulations
 """
-    abstract type AbstractMonteCarloProblem <: DEProblem
+$(TYPEDEF)
 """
 abstract type AbstractMonteCarloProblem <: DEProblem end
 
 """
-    abstract type AbstractMonteCarloEstimator <: DEProblem
+$(TYPEDEF)
 """
 abstract type AbstractMonteCarloEstimator <: DEProblem end
 
@@ -176,37 +174,37 @@ export MonteCarloProblem
 export MonteCarloSolution, MonteCarloTestSolution, MonteCarloSummary
 
 """
-    abstract type AbstractDiffEqInterpolation <: Function
+$(TYPEDEF)
 """
 abstract type AbstractDiffEqInterpolation <: Function end
 
 """
-    abstract type AbstractDEOptions
+$(TYPEDEF)
 """
 abstract type AbstractDEOptions end
 
 """
-    abstract type DECache
+$(TYPEDEF)
 """
 abstract type DECache end
 
 """
-    abstract type DECallback
+$(TYPEDEF)
 """
 abstract type DECallback end
 
 """
-    abstract type AbstractContinuousCallback <: DECallback
+$(TYPEDEF)
 """
 abstract type AbstractContinuousCallback <: DECallback end
 
 """
-    abstract type AbstractDiscreteCallback <: DECallback
+$(TYPEDEF)
 """
 abstract type AbstractDiscreteCallback <: DECallback end
 
 """
-    abstract type DEDataArray{T,N} <: AbstractArray{T,N}
+$(TYPEDEF)
 """
 abstract type DEDataArray{T,N} <: AbstractArray{T,N} end
 const DEDataVector{T} = DEDataArray{T,1}
@@ -214,63 +212,63 @@ const DEDataMatrix{T} = DEDataArray{T,2}
 
 # Integrators
 """
-    abstract type DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractSteadyStateIntegrator{Alg, IIP, U} <: DEIntegrator{Alg, IIP, U, Nothing}
+$(TYPEDEF)
 """
 abstract type AbstractSteadyStateIntegrator{Alg, IIP, U} <: DEIntegrator{Alg, IIP, U, Nothing} end
 
 """
-    abstract type AbstractODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractSecondOrderODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractSecondOrderODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractRODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractRODEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractSDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractSDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractDDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractDDEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 """
-    abstract type AbstractDAEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T}
+$(TYPEDEF)
 """
 abstract type AbstractDAEIntegrator{Alg, IIP, U, T} <: DEIntegrator{Alg, IIP, U, T} end
 
 # Solutions
 """
-    abstract type AbstractNoTimeSolution{T,N} <: AbstractArray{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractNoTimeSolution{T,N} <: AbstractArray{T,N} end
 
 """
-    abstract type AbstractTimeseriesSolution{T,N} <: AbstractDiffEqArray{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractTimeseriesSolution{T,N} <: AbstractDiffEqArray{T,N} end
 
 """
-    abstract type AbstractMonteCarloSolution{T,N} <: AbstractVectorOfArray{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractMonteCarloSolution{T,N} <: AbstractVectorOfArray{T,N} end
 
 """
-    abstract type AbstractNoiseProcess{T,N,isinplace} <: AbstractDiffEqArray{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractNoiseProcess{T,N,isinplace} <: AbstractDiffEqArray{T,N} end
 
@@ -281,76 +279,76 @@ const DESolution = Union{AbstractTimeseriesSolution,
 export DESolution
 
 """
-    abstract type AbstractSteadyStateSolution{T,N} <: AbstractNoTimeSolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractSteadyStateSolution{T,N} <: AbstractNoTimeSolution{T,N} end
 
 """
-    abstract type AbstractAnalyticalSolution{T,N} <: AbstractTimeseriesSolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractAnalyticalSolution{T,N} <: AbstractTimeseriesSolution{T,N} end
 
 """
-    abstract type AbstractODESolution{T,N} <: AbstractTimeseriesSolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractODESolution{T,N} <: AbstractTimeseriesSolution{T,N} end
 
 # Needed for plot recipes
 """
-    abstract type AbstractDDESolution{T,N} <: AbstractODESolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractDDESolution{T,N} <: AbstractODESolution{T,N} end
 
 """
-    abstract type AbstractRODESolution{T,N} <: AbstractODESolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractRODESolution{T,N} <: AbstractODESolution{T,N} end
 
 """
-    abstract type AbstractDAESolution{T,N} <: AbstractODESolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractDAESolution{T,N} <: AbstractODESolution{T,N} end
 
 """
-    abstract type AbstractSensitivitySolution{T,N}
+$(TYPEDEF)
 """
 abstract type AbstractSensitivitySolution{T,N} end
 
 # Misc
 """
-    abstract type Tableau
+$(TYPEDEF)
 """
 abstract type Tableau end
 
 """
-    abstract type ODERKTableau <: Tableau
+$(TYPEDEF)
 """
 abstract type ODERKTableau <: Tableau end
 
 """
-    abstract type DECostFunction
+$(TYPEDEF)
 """
 abstract type DECostFunction end
 
 """
-    abstract type AbstractDiffEqOperator{T}
+$(TYPEDEF)
 """
 abstract type AbstractDiffEqOperator{T} end
 
 """
-    abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T}
+$(TYPEDEF)
 """
 abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T} end
 
 """
-    abstract type AbstractDiffEqFunction{iip} <: Function
+$(TYPEDEF)
 
 Base for types defining differential equation functions.
 """
 abstract type AbstractDiffEqFunction{iip} <: Function end
 
 """
-    abstract type AbstractReactionNetwork <: Function
+$(TYPEDEF)
 """
 abstract type AbstractReactionNetwork <: Function end
 
@@ -393,12 +391,12 @@ include("remake.jl")
 include("init.jl")
 
 """
-    abstract type AbstractParameterizedFunction{iip} <: AbstractODEFunction{iip}
+$(TYPEDEF)
 """
 abstract type AbstractParameterizedFunction{iip} <: AbstractODEFunction{iip} end
 
 """
-    struct ConvergenceSetup{P,C}
+$(TYPEDEF)
 """
 struct ConvergenceSetup{P,C}
     probs::P

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -1,6 +1,17 @@
 const RECOMPILE_BY_DEFAULT = true
 
+"""
+    abstract type AbstractODEFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractODEFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct ODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{iip}
+
+TODO
+"""
 struct ODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{iip}
   f::F
   mass_matrix::TMM
@@ -14,6 +25,11 @@ struct ODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{ii
   syms::S
 end
 
+"""
+    struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
+
+TODO
+"""
 struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
   f1::F1
   f2::F2
@@ -22,6 +38,11 @@ struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
   analytic::Ta
 end
 
+"""
+    struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
+
+TODO
+"""
 struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
   f1::F1
   f2::F2
@@ -29,7 +50,18 @@ struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
   analytic::Ta
 end
 
+"""
+    abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
+
+TODO
+"""
 struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
   f::F
   mass_matrix::TMM
@@ -43,14 +75,36 @@ struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{ii
   syms::S
 end
 
+"""
+    abstract type AbstractDiscreteFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractDiscreteFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct DiscreteFunction{iip,F,Ta,S} <: AbstractDiscreteFunction{iip}
+
+TODO
+"""
 struct DiscreteFunction{iip,F,Ta,S} <: AbstractDiscreteFunction{iip}
   f::F
   analytic::Ta
   syms::S
 end
 
+"""
+    abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct SDEFunction{iip,F,G,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
+
+TODO
+"""
 struct SDEFunction{iip,F,G,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
   f::F
   g::G
@@ -66,6 +120,11 @@ struct SDEFunction{iip,F,G,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFuncti
   syms::S
 end
 
+"""
+    struct SplitSDEFunction{iip,F1,F2,G,TMM,C,Ta} <: AbstractSDEFunction{iip}
+
+TODO
+"""
 struct SplitSDEFunction{iip,F1,F2,G,TMM,C,Ta} <: AbstractSDEFunction{iip}
   f1::F1
   f2::F2
@@ -75,7 +134,18 @@ struct SplitSDEFunction{iip,F1,F2,G,TMM,C,Ta} <: AbstractSDEFunction{iip}
   analytic::Ta
 end
 
+"""
+    abstract type AbstractRODEFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractRODEFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct RODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
+
+TODO
+"""
 struct RODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
   f::F
   mass_matrix::TMM
@@ -89,7 +159,18 @@ struct RODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{
   syms::S
 end
 
+"""
+    abstract type AbstractDAEFunction{iip} <: AbstractDiffEqFunction{iip}
+
+TODO
+"""
 abstract type AbstractDAEFunction{iip} <: AbstractDiffEqFunction{iip} end
+
+"""
+    struct DAEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDAEFunction{iip}
+
+TODO
+"""
 struct DAEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDAEFunction{iip}
   f::F
   analytic::Ta

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -1,14 +1,14 @@
 const RECOMPILE_BY_DEFAULT = true
 
 """
-    abstract type AbstractODEFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractODEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct ODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -26,7 +26,7 @@ struct ODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractODEFunction{ii
 end
 
 """
-    struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -39,7 +39,7 @@ struct SplitFunction{iip,F1,F2,TMM,C,Ta} <: AbstractODEFunction{iip}
 end
 
 """
-    struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -51,14 +51,14 @@ struct DynamicalODEFunction{iip,F1,F2,TMM,Ta} <: AbstractODEFunction{iip}
 end
 
 """
-    abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractDDEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -76,14 +76,14 @@ struct DDEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDDEFunction{ii
 end
 
 """
-    abstract type AbstractDiscreteFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractDiscreteFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct DiscreteFunction{iip,F,Ta,S} <: AbstractDiscreteFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -94,14 +94,14 @@ struct DiscreteFunction{iip,F,Ta,S} <: AbstractDiscreteFunction{iip}
 end
 
 """
-    abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractSDEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct SDEFunction{iip,F,G,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -121,7 +121,7 @@ struct SDEFunction{iip,F,G,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S,GG} <: AbstractSDEFuncti
 end
 
 """
-    struct SplitSDEFunction{iip,F1,F2,G,TMM,C,Ta} <: AbstractSDEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -135,14 +135,14 @@ struct SplitSDEFunction{iip,F1,F2,G,TMM,C,Ta} <: AbstractSDEFunction{iip}
 end
 
 """
-    abstract type AbstractRODEFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractRODEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct RODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
@@ -160,14 +160,14 @@ struct RODEFunction{iip,F,TMM,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractRODEFunction{
 end
 
 """
-    abstract type AbstractDAEFunction{iip} <: AbstractDiffEqFunction{iip}
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractDAEFunction{iip} <: AbstractDiffEqFunction{iip} end
 
 """
-    struct DAEFunction{iip,F,Ta,Tt,TJ,JP,TW,TWt,TPJ,S} <: AbstractDAEFunction{iip}
+$(TYPEDEF)
 
 TODO
 """

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -2,9 +2,13 @@ const DISCRETE_INPLACE_DEFAULT = convert(DiscreteFunction{true},(du,u,p,t) -> du
 const DISCRETE_OUTOFPLACE_DEFAULT = convert(DiscreteFunction{false},(u,p,t) -> u)
 
 """
-    struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
+$(TYPEDEF)
 
 Defines a discrete problem.
+
+# Fields
+
+$(FIELDS)
 """
 struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
   """The function in the map."""
@@ -57,7 +61,7 @@ function DiscreteProblem(f,u0,tspan::Tuple,p=nothing;kwargs...)
 end
 
 """
-    DiscreteProblem{isinplace}(u0,tspan;kwargs...)
+$(SIGNATURES)
 
 Define a discrete problem with the identity map.
 """

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -1,11 +1,21 @@
 const DISCRETE_INPLACE_DEFAULT = convert(DiscreteFunction{true},(du,u,p,t) -> du.=u)
 const DISCRETE_OUTOFPLACE_DEFAULT = convert(DiscreteFunction{false},(u,p,t) -> u)
 
+"""
+    struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
+
+Defines a discrete problem.
+"""
 struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
+  """The function in the map."""
   f::F
+  """The initial condition."""
   u0::uType
+  """The timespan for the problem."""
   tspan::tType
+  """The parameter values of the function."""
   p::P
+  """ A callback to be applied to every solver which uses the problem."""
   callback::C
   @add_kwonly function DiscreteProblem{iip}(f::AbstractDiscreteFunction{iip},
                                             u0,tspan::Tuple,p=nothing;
@@ -32,6 +42,11 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   end
 end
 
+"""
+    DiscreteProblem{isinplace}(f,u0,tspan,p=nothing,callback=nothing)
+
+Defines a discrete problem with the specified functions.
+"""
 function DiscreteProblem(f::AbstractDiscreteFunction,u0,tspan::Tuple,p=nothing;kwargs...)
   DiscreteProblem{isinplace(f)}(f,u0,tspan,p;kwargs...)
 end
@@ -41,6 +56,11 @@ function DiscreteProblem(f,u0,tspan::Tuple,p=nothing;kwargs...)
   DiscreteProblem(convert(DiscreteFunction{iip},f),u0,tspan,p;kwargs...)
 end
 
+"""
+    DiscreteProblem{isinplace}(u0,tspan;kwargs...)
+
+Define a discrete problem with the identity map.
+"""
 function DiscreteProblem(u0,tspan::Tuple,p::Tuple;kwargs...)
   iip = typeof(u0) <: AbstractArray
   if iip

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -1,5 +1,5 @@
 """
-    struct StandardODEProblem
+$(TYPEDEF)
 
 TODO
 """
@@ -7,10 +7,13 @@ struct StandardODEProblem end
 
 # Mu' = f
 """
-    struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
-               AbstractODEProblem{uType,tType,isinplace}
+$(TYPEDEF)
 
 Defines an ODE problem.
+
+# Fields
+
+$(FIELDS)
 """
 struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
                AbstractODEProblem{uType,tType,isinplace}
@@ -64,14 +67,14 @@ function ODEProblem(f,u0,tspan,p=nothing;kwargs...)
 end
 
 """
-    abstract type AbstractDynamicalODEProblem
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractDynamicalODEProblem end
 
 """
-    struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
+$(TYPEDEF)
 
 TODO
 """
@@ -111,7 +114,7 @@ end
 
 # u'' = f(t,u,du,ddu)
 """
-    struct SecondOrderODEProblem{iip} <: AbstractDynamicalODEProblem
+$(TYPEDEF)
 
 TODO
 """
@@ -169,14 +172,14 @@ function SecondOrderODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;kw
 end
 
 """
-    abstract type AbsstractSplitODEProblem
+$(TYPEDEF)
 
 TODO
 """
 abstract type AbstractSplitODEProblem end
 
 """
-    struct SplitODEProblem{iip} <: AbstractSplitODEProblem
+$(TYPEDEF)
 
 TODO
 """
@@ -209,7 +212,7 @@ function SplitODEProblem{iip}(f1,f2,u0,tspan,p=nothing;kwargs...) where iip
 end
 
 """
-    SplitODEProblem(f::SplitFunction,u0,tspan,p=nothing;kwargs...)
+$(SIGNATURES)
 
 Define a split ODE problem from a [`SplitFunction`](@ref).
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -1,13 +1,30 @@
+"""
+    struct StandardODEProblem
+
+TODO
+"""
 struct StandardODEProblem end
 
 # Mu' = f
+"""
+    struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
+               AbstractODEProblem{uType,tType,isinplace}
+
+Defines an ODE problem.
+"""
 struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
                AbstractODEProblem{uType,tType,isinplace}
+  """The function in the ODE."""
   f::F
+  """The initial condition."""
   u0::uType
+  """The timespan for the problem."""
   tspan::tType
+  """The parameter values of the ODE function."""
   p::P
+  """A callback to be applied to every solver which uses the problem."""
   callback::C
+  """TODO"""
   problem_type::PT
   @add_kwonly function ODEProblem{iip}(f::AbstractODEFunction{iip},
                                        u0,tspan,p=nothing,
@@ -21,11 +38,23 @@ struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
        f,u0,_tspan,p,callback,problem_type)
   end
 
+  """
+      ODEProblem{isinplace}(f,u0,tspan,p=nothing,callback=CallbackSet())
+
+  Define an ODE problem with the specified function.
+  `isinplace` optionally sets whether the function is inplace or not.
+  This is determined automatically, but not inferred.
+  """
   function ODEProblem{iip}(f,u0,tspan,p=nothing;kwargs...) where {iip}
     ODEProblem(convert(ODEFunction{iip},f),u0,tspan,p;kwargs...)
   end
 end
 
+"""
+    ODEProblem(f::ODEFunction,u0,tspan,p=nothing,callback=CallbackSet())
+
+Define an ODE problem from a [`ODEFunction`](@ref).
+"""
 function ODEProblem(f::AbstractODEFunction,u0,tspan,args...;kwargs...)
   ODEProblem{isinplace(f)}(f,u0,tspan,args...;kwargs...)
 end
@@ -34,27 +63,76 @@ function ODEProblem(f,u0,tspan,p=nothing;kwargs...)
   ODEProblem(convert(ODEFunction,f),u0,tspan,p;kwargs...)
 end
 
+"""
+    abstract type AbstractDynamicalODEProblem
+
+TODO
+"""
 abstract type AbstractDynamicalODEProblem end
 
+"""
+    struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
+
+TODO
+"""
 struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
 # u' = f1(v)
 # v' = f2(t,u)
+"""
+    DynamicalODEProblem(f::DynamicalODEFunction,v0,u0,tspan,p=nothing,callback=CallbackSet())
+
+Define a dynamical ODE function from a [`DynamicalODEFunction`](@ref).
+"""
 function DynamicalODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;kwargs...)
   ODEProblem(f,(du0,u0),tspan,p;kwargs...)
 end
 function DynamicalODEProblem(f1,f2,du0,u0,tspan,p=nothing;kwargs...)
   ODEProblem(DynamicalODEFunction(f1,f2),(du0,u0),tspan,p;kwargs...)
 end
+
+"""
+    DynamicalODEProblem{isinplace}(f1,f2,v0,u0,tspan,p=nothing,callback=CallbackSet())
+
+Define a dynamical ODE problem from the two functions `f1` and `f2`.
+
+# Arguments
+* `f1` and `f2`: The functions in the ODE.
+* `v0` and `u0`: The initial conditions.
+* `tspan`: The timespan for the problem.
+* `p`: Parameter values for `f1` and `f2`.
+* `callback`: A callback to be applied to every solver which uses the problem. Defaults to nothing.
+
+`isinplace` optionally sets whether the function is inplace or not.
+This is determined automatically, but not inferred.
+"""
 function DynamicalODEProblem{iip}(f1,f2,du0,u0,tspan,p=nothing;kwargs...) where iip
   ODEProblem(DynamicalODEFunction{iip}(f1,f2),(du0,u0),tspan,p;kwargs...)
 end
 
 # u'' = f(t,u,du,ddu)
+"""
+    struct SecondOrderODEProblem{iip} <: AbstractDynamicalODEProblem
+
+TODO
+"""
 struct SecondOrderODEProblem{iip} <: AbstractDynamicalODEProblem end
 function SecondOrderODEProblem(f,du0,u0,tspan,p=nothing;kwargs...)
   iip = isinplace(f,5)
   SecondOrderODEProblem{iip}(f,du0,u0,tspan,p;kwargs...)
 end
+
+"""
+    SecondOrderODEProblem{isinplace}(f,du0,u0,tspan,p=nothing,callback=CallbackSet())
+
+Define a second order ODE problem with the specified function.
+
+# Arguments
+* `f`: The function for the second derivative.
+* `du0`: The initial derivative.
+* `u0`: The initial condition.
+* `tspan`: The timespan for the problem.
+* `callback`: A callback to be applied to every solver which uses the problem. Defaults to nothing.
+"""
 function SecondOrderODEProblem{iip}(f,du0,u0,tspan,p=nothing;kwargs...) where iip
   if iip
     f2 = function (du,v,u,p,t)
@@ -90,17 +168,51 @@ function SecondOrderODEProblem(f::DynamicalODEFunction,du0,u0,tspan,p=nothing;kw
   end
 end
 
+"""
+    abstract type AbsstractSplitODEProblem
+
+TODO
+"""
 abstract type AbstractSplitODEProblem end
+
+"""
+    struct SplitODEProblem{iip} <: AbstractSplitODEProblem
+
+TODO
+"""
 struct SplitODEProblem{iip} <: AbstractSplitODEProblem end
 # u' = Au + f
 function SplitODEProblem(f1,f2,u0,tspan,p=nothing;kwargs...)
   f = SplitFunction(f1,f2)
   SplitODEProblem(f,u0,tspan,p;kwargs...)
 end
+"""
+    SplitODEProblem{isinplace}(f1,f2,u0,tspan,p=nothing;kwargs...)
+
+Define a split ODE problem from separate functions `f1` and `f2`.
+
+# Arguments
+* `f1`, `f2`: The functions in the ODE.
+* `u0`: The initial condition.
+* `tspan`: The timespan for the problem.
+* `p`: The parameters for the problem.
+* `callback`: A callback to be applied to every solver which uses the problem. Defaults to nothing.
+
+The `isinplace parameter` can be omitted and will be determined using the
+signature of `f2`. Note that both `f1` and `f2` should support the in-place style if
+`isinplace` is true or they should both support the out-of-place style if
+`isinplace` is false. You cannot mix up the two styles.
+"""
 function SplitODEProblem{iip}(f1,f2,u0,tspan,p=nothing;kwargs...) where iip
   f = SplitFunction{iip}(f1,f2)
   SplitODEProblem(f,u0,tspan,p;kwargs...)
 end
+
+"""
+    SplitODEProblem(f::SplitFunction,u0,tspan,p=nothing;kwargs...)
+
+Define a split ODE problem from a [`SplitFunction`](@ref).
+"""
 SplitODEProblem(f::SplitFunction,u0,tspan,p=nothing;kwargs...) =
   SplitODEProblem{isinplace(f)}(f,u0,tspan,p;kwargs...)
 function SplitODEProblem{iip}(f::SplitFunction,u0,tspan,p=nothing;kwargs...) where iip

--- a/src/problems/problem_traits.jl
+++ b/src/problems/problem_traits.jl
@@ -1,6 +1,17 @@
-is_diagonal_noise(prob::DEProblem) = false 
+"""
+    is_diagonal_noise(prob::DEProblem)
+
+TODO
+"""
+is_diagonal_noise(prob::DEProblem) = false
 is_diagonal_noise(prob::AbstractRODEProblem{uType,tType,isinplace,ND}) where {uType,tType,isinplace,ND} = ND <: Nothing
 
+"""
+    isinplace(prob::DEProblem)
+
+Determine whether the function of the given problem operates in place or not.
+"""
+function isinplace(prob::DEProblem) end
 isinplace(prob::AbstractODEProblem{uType,tType,iip}) where {uType,tType,iip} = iip
 isinplace(prob::AbstractSteadyStateProblem{uType,iip}) where {uType,iip} = iip
 isinplace(prob::AbstractRODEProblem{uType,tType,iip,ND}) where {uType,tType,iip,ND} = iip

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -1,3 +1,9 @@
+"""
+    promote_tspan(tspan)
+
+Convert the `tspan` field of a `DEProblem` to a `(tmin, tmax)` tuple, where both
+elements are of the same type. If `tspan` is a function, returns it as-is.
+"""
 promote_tspan(tspan::Tuple{T,T}) where T = tspan
 function promote_tspan(tspan::Tuple{T1,T2}) where {T1,T2}
   T = promote_type(map(typeof,tspan)...)

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,18 +1,39 @@
 # Mu' = f
+"""
+    struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
+
+Defines a steady state problem.
+"""
 struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
+  """f: The function in the ODE."""
   f::F
+  """The initial guess for the steady state."""
   u0::uType
+  """Parameter values for the ODE function."""
   p::P
   @add_kwonly function SteadyStateProblem{iip}(f::AbstractODEFunction{iip},
                                                u0,p=nothing) where {iip}
     new{typeof(u0),isinplace(f),typeof(p),typeof(f)}(f,u0,p)
   end
 
+  """
+      SteadyStateProblem{iip}(f,u0,p=nothing)
+
+  Define a steady state problem using the given function.
+  `isinplace` optionally sets whether the function is inplace or not.
+  This is determined automatically, but not inferred.
+  """
   function SteadyStateProblem{iip}(f,u0,p=nothing) where iip
     SteadyStateProblem(ODEFunction{iip}(f),u0,p)
   end
 end
 
+"""
+    SteadyStateProblem(f::AbstractODEFunction,u0,p=nothing;kwargs...)
+
+Define a steady state problem using an instance of
+[`AbstractODEFunction`](@ref).
+"""
 function SteadyStateProblem(f::AbstractODEFunction,u0,p=nothing;kwargs...)
   SteadyStateProblem{isinplace(f)}(f,u0,p;kwargs...)
 end
@@ -21,5 +42,10 @@ function SteadyStateProblem(f,u0,p=nothing;kwargs...)
   SteadyStateProblem(ODEFunction(f),u0,p;kwargs...)
 end
 
+"""
+    SteadyStateProblem(prob::AbstractODEProblem)
+
+Define a steady state problem from a standard ODE problem.
+"""
 SteadyStateProblem(prob::AbstractODEProblem) =
       SteadyStateProblem{isinplace(prob)}(prob.f,prob.u0,prob.p)

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,8 +1,12 @@
 # Mu' = f
 """
-    struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
+$(TYPEDEF)
 
 Defines a steady state problem.
+
+# Fields
+
+$(FIELDS)
 """
 struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
   """f: The function in the ODE."""
@@ -17,7 +21,7 @@ struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uTy
   end
 
   """
-      SteadyStateProblem{iip}(f,u0,p=nothing)
+  $(SIGNATURES)
 
   Define a steady state problem using the given function.
   `isinplace` optionally sets whether the function is inplace or not.
@@ -29,7 +33,7 @@ struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uTy
 end
 
 """
-    SteadyStateProblem(f::AbstractODEFunction,u0,p=nothing;kwargs...)
+$(SIGNATURES)
 
 Define a steady state problem using an instance of
 [`AbstractODEFunction`](@ref).
@@ -43,7 +47,7 @@ function SteadyStateProblem(f,u0,p=nothing;kwargs...)
 end
 
 """
-    SteadyStateProblem(prob::AbstractODEProblem)
+$(SIGNATURES)
 
 Define a steady state problem from a standard ODE problem.
 """


### PR DESCRIPTION
This is a work in progress of documentation for the package's API, which isn't really covered in depth in DiffEqDocs.jl. I'm basically just adding docstrings to the important functions and types and then organizing references to them in some Documenter.jl files. So far I've covered most of the problem types and added stubs for the `AbstractDiffEqFunction` subtypes.

My goal here is to get enough of the documentation structure set up so that myself and others can continue filling in the docstrings in smaller increments.