### PR TITLE
Add better default linsolve and easy GMRES

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,3 +10,4 @@ TreeViews
 Roots
 DocStringExtensions
 IterativeSolvers
+RecursiveFactorization

--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ TableTraits 0.3.0
 TreeViews
 Roots
 DocStringExtensions
+IterativeSolvers

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -446,7 +446,7 @@ export ContinuousCallback, DiscreteCallback, CallbackSet
 
 export initialize!
 
-export LinSolveFactorize, DEFAULT_LINSOLVE
+export LinSolveFactorize, DEFAULT_LINSOLVE, LinSolveGMRES
 
 export AffineDiffEqOperator, update_coefficients!, update_coefficients, is_constant,
        has_expmv!, has_expmv, has_exp, has_mul, has_mul!, has_ldiv, has_ldiv!

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -1,7 +1,8 @@
 module DiffEqBase
 
 using RecipesBase, RecursiveArrayTools, Compat,
-      Requires, TableTraits, IteratorInterfaceExtensions, TreeViews
+      Requires, TableTraits, IteratorInterfaceExtensions, TreeViews,
+      IterativeSolvers, RecursiveFactorization
 
 using Roots # callbacks
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -87,4 +87,12 @@ function __init__()
     @inline ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedReal,t::Flux.Tracker.TrackedReal) = abs(u)
   end
 
+  # Piracy, should get upstreamed
+  @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
+    function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CuQR,b::CuArrays.CuArray)
+      _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+      x .= vec(_x)
+    end
+  end
+
 end

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -31,7 +31,7 @@ mutable struct DefaultLinSolve
 end
 DefaultLinSolve() = DefaultLinSolve(nothing)
 
-function (f::DefaultLinSolve)(x,A,b,update_matrix=false)
+function (p::DefaultLinSolve)(x,A,b,update_matrix=false)
   if update_matrix
     if typeof(A) <: Matrix
       p.A = lu!(A)

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -41,15 +41,20 @@ function (p::DefaultLinSolve)(x,A,b,update_matrix=false)
       end
     elseif typeof(A) <: SparseMatrixCSC
       p.A = factorize(A)
+    elseif !(typeof(A) <: AbstractDiffEqOperator)
+      # Most likely QR is the one that is overloaded
+      # Works on things like CuArrays
+      p.A = qr(A)
     end
   end
-  if typeof(A) <: SparseMatrixCSC
-    ldiv!(x,p.A,b) # No 2-arg form for SparseArrays!
-  elseif typeof(A) <: Matrix
+
+  if typeof(A) <: Matrix # No 2-arg form for SparseArrays!
     x .= b
     ldiv!(p.A,x)
   elseif typeof(A) <: AbstractDiffEqOperator
     gmres!(x,A,b)
+  else
+    ldiv!(x,p.A,b)
   end
 end
 

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -76,7 +76,6 @@ const DEFAULT_LINSOLVE = DefaultLinSolve()
 struct LinSolveGMRES{A}
   kwargs::A
 end
-LinSolveGMRES() = LinSolveGMRES(nothing)
 LinSolveGMRES(;kwargs...) = LinSolveGMRES(kwargs)
 
 function (f::LinSolveGMRES)(x,A,b,update_matrix=false)

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -51,8 +51,10 @@ function (p::DefaultLinSolve)(x,A,b,update_matrix=false)
   if typeof(A) <: Matrix # No 2-arg form for SparseArrays!
     x .= b
     ldiv!(p.A,x)
+  elseif typeof(A) <: DiffEqArrayOperator
+    ldiv!(x,p.A,b)
   elseif typeof(A) <: AbstractDiffEqOperator
-    gmres!(x,A,b)
+    IterativeSolvers.gmres!(x,A,b)
   else
     ldiv!(x,p.A,b)
   end

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -69,6 +69,6 @@ function (f::LinSolveGMRES)(x,A,b,update_matrix)
   gmres!(x,A,b;f.kwargs...)
 end
 
-function (f::LinSolveGMRES)(::Type{Val{:init}},f,u0_prototype)
-  LinSolveGMRES(f.kwargs)
+function (p::LinSolveGMRES)(::Type{Val{:init}},f,u0_prototype)
+  LinSolveGMRES(p.kwargs)
 end

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -34,7 +34,8 @@ DefaultLinSolve() = DefaultLinSolve(nothing)
 function (p::DefaultLinSolve)(x,A,b,update_matrix=false)
   if update_matrix
     if typeof(A) <: Matrix
-      if size(A,1) <= 500
+      blasvendor = BLAS.vendor()
+      if (blasvendor === :openblas || blasvendor === :openblas64) && size(A,1) <= 500 # if the user doesn't use OpenBLAS, we assume that is a much better BLAS implementation like MKL
         p.A = RecursiveFactorization.lu!(A)
       else
         p.A = lu!(A)

--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -34,12 +34,16 @@ DefaultLinSolve() = DefaultLinSolve(nothing)
 function (p::DefaultLinSolve)(x,A,b,update_matrix=false)
   if update_matrix
     if typeof(A) <: Matrix
-      p.A = lu!(A)
+      if size(A,1) <= 500
+        p.A = RecursiveFactorization.lu!(A)
+      else
+        p.A = lu!(A)
+      end
     elseif typeof(A) <: SparseMatrixCSC
       p.A = factorize(A)
     end
   end
-  if typeof(p.A) <: SuiteSparse.UMFPACK.UmfpackLU || typeof(p.factorization) <: typeof(lu)
+  if typeof(A) <: SparseMatrixCSC
     ldiv!(x,p.A,b) # No 2-arg form for SparseArrays!
   elseif typeof(A) <: Matrix
     x .= b


### PR DESCRIPTION
This default works with dense and sparse arrays, along with lazy operator definitions, out of the box.

Additionally, `linsolve = LinSolveGMRES()` now is a simple way to change to GMRES.