### PR TITLE
Add MonteCarloMeasurements ODE_DEFAULT_NORM

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -45,6 +45,20 @@ function __init__()
     end
     @inline ODE_DEFAULT_NORM(u::Measurements.Measurement,t) = abs(Measurements.value(u))
   end
+  
+  @require MonteCarloMeasurements="0987c9cc-fe09-11e8-30f0-b96dd679fdca" begin
+
+    value(x::MonteCarloMeasurements.AbstractParticles) = mean(x)
+
+    # Support adaptive steps should be errorless
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:MonteCarloMeasurements.AbstractParticles,N},t) where {N}
+      sqrt(mean(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))))
+    end
+    @inline function ODE_DEFAULT_NORM(u::Array{<:MonteCarloMeasurements.AbstractParticles,N},t) where {N}
+      sqrt(mean(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))))
+    end
+    @inline ODE_DEFAULT_NORM(u::MonteCarloMeasurements.AbstractParticles,t) = abs(value(u))
+  end
 
   @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" begin
     # Support adaptive errors should be errorless for exponentiation


### PR DESCRIPTION
This is still WIP since I can not get it to work, the code below causes a call to 
`convert(Float64, ::Particles{Float64,500})` which is not supported unless all particles are the same. Measurements.jl handles this convert the same, i.e., only allows it if the error is zero.

After having added the code in this PR, I have
```julia
julia> g
(500 Particles: 9.79 ± 0.02)

julia> DiffEqBase.ODE_DEFAULT_NORM(g,1.)
9.789991179929432
```
which indicates that the method is there and is producing a float as expected.

Any help appreciated :)

```julia
using MonteCarloMeasurements, OrdinaryDiffEq, Plots
using MonteCarloMeasurements: ±
g = 9.79 ± 0.02; # Gravitational constants
L = 1.00 ± 0.01; # Length of the pendulum

#Initial Conditions
u₀ = [0 ± 0, π / 60 ± 0.01] # Initial speed and initial angle
tspan = (0.0, 6.3)

#Define the problem
function simplependulum(du,u,p,t)
    θ  = u[1]
    dθ = u[2]
    du[1] = dθ
    du[2] = -(g/L)*θ
end

#Pass to solvers
prob = ODEProblem(simplependulum, u₀, tspan)
sol = solve(prob, Tsit5(), reltol = 1e-6)
```
