### PR TITLE
Update init for MonteCarloMeasurements

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -54,8 +54,8 @@ function __init__()
     @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:MonteCarloMeasurements.AbstractParticles,N},t) where {N}
       sqrt(mean(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))))
     end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:MonteCarloMeasurements.AbstractParticles,N},t) where {N}
-      sqrt(mean(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))))
+    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:MonteCarloMeasurements.AbstractParticles,N},t::AbstractArray{<:MonteCarloMeasurements.AbstractParticles,N}) where {N}
+      sqrt(mean(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(value.(t)))))
     end
     @inline ODE_DEFAULT_NORM(u::MonteCarloMeasurements.AbstractParticles,t) = abs(value(u))
   end


### PR DESCRIPTION
> Should it not remove the swarm when time is a swarm? I'm not sure how to think about that case here.

You are right. I think this PR makes a bit more sense.

Btw, many of the inits provide two methods, one which is slightly more specialized to `Array` instead of `AbstractArray`, but they otherwise do the same thing. Is there a reason for this or is it due to pattern matching and copy-paste when some previous packages have been inited? Example:
```julia
    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Measurements.Measurement,N},t) where {N}
      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((Measurements.value(x) for x in u),Iterators.repeated(t))) / length(u))
    end
    @inline function ODE_DEFAULT_NORM(u::Array{<:Measurements.Measurement,N},t) where {N}
      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((Measurements.value(x) for x in u),Iterators.repeated(t))) / length(u))
    end
```