### PR TITLE
[WIP] VectorContinuousCallbacks

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -450,7 +450,7 @@ export DEDataArray, DEDataVector, DEDataMatrix
 export ODEFunction, DiscreteFunction, SplitFunction, DAEFunction, DDEFunction,
        SDEFunction, SplitSDEFunction, RODEFunction
 
-export ContinuousCallback, DiscreteCallback, CallbackSet
+export ContinuousCallback, DiscreteCallback, CallbackSet, VectorContinuousCallback
 
 export initialize!
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -177,7 +177,7 @@ function get_tmp(integrator::DEIntegrator, callback)
   return tmp
 end
 
-function get_condition(integrator::DEIntegrator, callback, abst, out = nothing)
+function get_condition(integrator::DEIntegrator, callback, abst)
   tmp = get_tmp(integrator, callback)
   ismutable = !(tmp === nothing)
   if abst == integrator.t

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -309,7 +309,7 @@ end
 
   integrator.sol.destats.ncondition += 1
   if callback isa VectorContinuousCallback
-    event_idx = findall(x-> ((x[1]<0 && !(typeof(callback.affect!)<:Nothing)) || (x[1]>0 && !(typeof(callback.affect_neg!)<:Nothing))) && x[1]*x[2]<=0, collect(zip(prev_sign,next_sign)))
+    event_idx = findall(x-> ((prev_sign[x]<0 && !(typeof(callback.affect!)<:Nothing)) || (prev_sign[x]>0 && !(typeof(callback.affect_neg!)<:Nothing))) && prev_sign[x]*next_sign[x]<=0, keys(prev_sign))
     if length(event_idx) != 0
       event_occurred = true
       interp_index = callback.interp_points
@@ -318,7 +318,7 @@ end
       for i in 2:length(Θs)
         abst = integrator.tprev+integrator.dt*Θs[i]
         new_sign = get_condition(integrator, callback, abst)
-        _event_idx = findall(x -> ((x[1]<0 && !(typeof(callback.affect!)<:Nothing)) || (x[1]>0 && !(typeof(callback.affect_neg!)<:Nothing))) && x[1]*x[2]<0, collect(zip(prev_sign,new_sign)))
+        _event_idx = findall(x -> ((prev_sign[x]<0 && !(typeof(callback.affect!)<:Nothing)) || (prev_sign[x]>0 && !(typeof(callback.affect_neg!)<:Nothing))) && prev_sign[x]*new_sign[x]<0, keys(prev_sign))
         if length(_event_idx) != 0
           event_occurred = true
           event_idx = _event_idx


### PR DESCRIPTION
An implementation of what was discussed in https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/331 and various Discourse posts. The idea is for the implementation to not be separate from the one used on ContinuousCallback, since that would promote code reuse and would allow ContinuousCallback to output things like a StaticVector and just work, which would be nice. However, dealing with the caches performantly seems to be an issue. Current issues are:

1. Breaking. Needs to add `previous_condition` and `callback_cache` to the integrator. This should be in the integrator and not in the callback in order to make it thread-safe. These should be allocated by the integrator to get the right element type, but the length needs to be given by the user when the callback is generated.
2.  Right now it has some allocations of `prev_sign` and `next_sign`. These should be integrator caches as well.
3. Right now for catching crossings I'm using `findfirst`. In reality, if there are multiple crossings happening in a given interval, you need to `findall` and then in the rootfinding to a vector rootfind to `findfirst`. However, `finall(true) = [true]`, making it inefficient on the scalar code. So something trickier needs to be done to that part of the code.
4. Since we cannot guarantee a single index in the rootfind, we still need a vector rootfinding method. At least a bisection.