### PR TITLE
ODEFunction accepts both in- and out-of-place styles in function call

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -185,7 +185,30 @@ end
 
 ######### Backwards Compatibility Overloads
 
-(f::ODEFunction)(args...) = f.f(args...)
+# Out-of-place function, out-of-place signature
+function (f::ODEFunction{false})(u, p, t)
+  f.f(u, p, t)
+end
+
+# Out-of-place function, in-place signature
+function (f::ODEFunction{false})(du, u, p, t)
+  du[:] = f.f(u, p, t)
+  nothing
+end
+
+# In-place function, in-place signature
+function (f::ODEFunction{true})(u, p, t)
+  du = similar(u)
+  f.f(du, u, p, t)
+  return du
+end
+
+# In-place function, out-of-place signature
+function (f::ODEFunction{true})(du, u, p, t)
+  f.f(du, u, p, t)
+  nothing
+end
+
 (f::ODEFunction)(::Type{Val{:analytic}},args...) = f.analytic(args...)
 (f::ODEFunction)(::Type{Val{:tgrad}},args...) = f.tgrad(args...)
 (f::ODEFunction)(::Type{Val{:jac}},args...) = f.jac(args...)

--- a/test/diffeqfunction_tests.jl
+++ b/test/diffeqfunction_tests.jl
@@ -7,9 +7,18 @@ DE_f_ip = ODEFunction{true}(f_ip)
 DI_f = DiscreteFunction{false}(f_op)
 DI_f_ip = DiscreteFunction{true}(f_ip)
 du = zeros(3); u = [1.0,2.0,3.0]; p = nothing; t = 0.0
+
 @test DE_f(u,p,t) == u
+@test DE_f_ip(u,p,t) == u
+
+du .= NaN
+DE_f(du,u,p,t)
+@test du == u
+
+du .= NaN
 DE_f_ip(du,u,p,t)
 @test du == u
+
 @test DI_f(u,p,t) == u
 DI_f_ip(du,u,p,t)
 @test du == u


### PR DESCRIPTION
Updated `(f::ODEFunction)()` to work with both in-place and out-of-place arguments, regardless of whether the wrapped function is in place or not. I'm not sure if calling out-of-place functions with the in-place style is a common use case, but I think the reverse definitely is (especially in interactive use). You can now use both types interchangeably without having to know the type parameter (although of course most applications that need optimal performance will still have to specialize).

You could probably easily extend this to the rest of the `DEFunction` subtypes by writing a macro for it.