### PR TITLE
Set kappa to 1//100 instead of nothing

### DIFF
--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -37,7 +37,7 @@ struct NLFunctional{K,C} <: AbstractNLSolverAlgorithm
   max_iter::Int
 end
 
-NLFunctional(; κ=nothing, max_iter=10, fast_convergence_cutoff=1//5) = NLFunctional(κ, fast_convergence_cutoff, max_iter)
+NLFunctional(; κ=1//100, max_iter=10, fast_convergence_cutoff=1//5) = NLFunctional(κ, fast_convergence_cutoff, max_iter)
 
 struct NLAnderson{K,D,C} <: AbstractNLSolverAlgorithm
   κ::K
@@ -48,7 +48,7 @@ struct NLAnderson{K,D,C} <: AbstractNLSolverAlgorithm
   droptol::D
 end
 
-NLAnderson(; κ=nothing, max_iter=10, max_history::Int=5, aa_start::Int=1, droptol=nothing, fast_convergence_cutoff=1//5) =
+NLAnderson(; κ=1//100, max_iter=10, max_history::Int=5, aa_start::Int=1, droptol=nothing, fast_convergence_cutoff=1//5) =
   NLAnderson(κ, fast_convergence_cutoff, max_iter, max_history, aa_start, droptol)
 
 struct NLNewton{K,C1,C2} <: AbstractNLSolverAlgorithm
@@ -58,7 +58,7 @@ struct NLNewton{K,C1,C2} <: AbstractNLSolverAlgorithm
   new_W_dt_cutoff::C2
 end
 
-NLNewton(; κ=nothing, max_iter=10, fast_convergence_cutoff=1//5, new_W_dt_cutoff=1//5) = NLNewton(κ, max_iter, fast_convergence_cutoff, new_W_dt_cutoff)
+NLNewton(; κ=1//100, max_iter=10, fast_convergence_cutoff=1//5, new_W_dt_cutoff=1//5) = NLNewton(κ, max_iter, fast_convergence_cutoff, new_W_dt_cutoff)
 
 # caches
 

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -89,18 +89,16 @@ set_W_dt!(nlsolver::NLSolver, W_dt) = set_W_dt!(nlsolver.cache, W_dt)
 set_W_dt!(nlcache::NLNewtonCache, W_dt) = (nlcache.W_dt = W_dt; W_dt)
 set_W_dt!(nlcache::NLNewtonConstantCache, W_dt) = W_dt
 
-get_κ(nlalg::Union{NLAnderson,NLFunctional,NLNewton}) = nlalg.κ === nothing ? 1//100 : nlalg.κ
 function nlsolve_f end
 
 DiffEqBase.@def iipnlsolve begin
+  @unpack κ, fast_convergence_cutoff = alg.nlsolve
+
   # define additional fields of cache of non-linear solver
   z = similar(u); dz = similar(u); tmp = similar(u); b = similar(u)
   k = zero(rate_prototype)
 
-  # adapt options of non-linear solver to current integration problem
   uTolType = real(uBottomEltypeNoUnits)
-  κ = DiffEqBase.get_κ(alg.nlsolve)
-  fast_convergence_cutoff = alg.nlsolve.fast_convergence_cutoff
 
   # create cache of non-linear solver
   if alg.nlsolve isa NLNewton
@@ -174,13 +172,12 @@ DiffEqBase.@def iipnlsolve begin
 end
 
 DiffEqBase.@def oopnlsolve begin
+  @unpack κ, fast_convergence_cutoff = alg.nlsolve
+
   # define additional fields of cache of non-linear solver (all aliased)
   z = uprev; dz = z; tmp = z; b = z; k = rate_prototype
 
-  # define tolerances
   uTolType = real(uBottomEltypeNoUnits)
-  κ = DiffEqBase.get_κ(alg.nlsolve)
-  fast_convergence_cutoff = alg.nlsolve.fast_convergence_cutoff
 
   # create cache of non-linear solver
   if alg.nlsolve isa NLNewton


### PR DESCRIPTION
Seems like `κ` could be set to `1//100` instead of `nothing` by default, instead of setting it to `nothing`, checking for `nothing` during construction of the solver and its cache, and using `κ = 1//100` in that case. Feels a bit clearer to initialize it with `1//100` in the first place.