### PR TITLE
CallbackSet fix

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -239,8 +239,8 @@ function find_first_continuous_callback(integrator,tmin::Number,upcrossing::Numb
   end
 end
 
-function find_first_continuous_callback(integrator,tmin::Number,upcrossing::Number,event_occured::Bool,idx::Int,counter::Int,callback2,args...)
-  find_first_continuous_callback(integrator,find_first_continuous_callback(integrator,tmin,upcrossing,event_occured,idx,counter,callback2)...,args...)
+function find_first_continuous_callback(integrator,tmin::Number,upcrossing::Number,event_occured::Bool,event_idx::Int,idx::Int,counter::Int,callback2,args...)
+  find_first_continuous_callback(integrator,find_first_continuous_callback(integrator,tmin,upcrossing,event_occured,event_idx,idx,counter,callback2)...,args...)
 end
 
 @inline function determine_event_occurance(integrator,callback::VectorContinuousCallback,counter)


### PR DESCRIPTION
Fixes #249. This was not due to bad epsilon handling but was a bug. I forgot to add `event_idx` in one overload of `find_first_continuous_callback`. We really really need better callback tests. The recursive logic is weird and is prone to such errors.