### PR TITLE
Better epsilon handling in callbacks

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -282,6 +282,7 @@ end
 
     # Evaluate condition slightly in future
     abst = integrator.tprev+max(integrator.dt/10000,sign(integrator.dt)*100*eps(integrator.t))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing
@@ -360,6 +361,7 @@ end
 
     # Evaluate condition slightly in future
     abst = integrator.tprev+max(integrator.dt/10000,sign(integrator.dt)*100*eps(integrator.t))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing
@@ -429,10 +431,13 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             # But floating point error may make the end point negative
 
             sign_top = sign(zero_func(top_Θ))
-            bottom_θ += 2eps(typeof(bottom_θ))
+            offset = 2eps(typeof(bottom_θ))
+            bottom_θ += offset
             iter = 1
             while sign(zero_func(bottom_θ)) == sign_top && iter < 12
-              bottom_θ *= 5
+              bottom_θ -= offset
+              offset *= 5
+              bottom_θ += offset
               iter += 1
             end
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -429,14 +429,10 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             # But floating point error may make the end point negative
 
             sign_top = sign(zero_func(top_Θ))
-            offset = 2eps(typeof(bottom_θ))
-            bottom_θ += offset
+            bottom_θ += 2eps(typeof(bottom_θ))
             iter = 1
             while sign(zero_func(bottom_θ)) == sign_top && iter < 12
-              bottom_θ -= offset
-              offset *= 5
-              bottom_θ += offset
-              iter += 1
+              bottom_θ *= 5
             end
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -281,7 +281,6 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+max(integrator.dt/10000,sign(integrator.dt)*100*eps(integrator.t))
     abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
@@ -360,7 +359,6 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+max(integrator.dt/10000,sign(integrator.dt)*100*eps(integrator.t))
     abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 


### PR DESCRIPTION
Lets discuss about how we could actually better our epsilon handling. For those unfamiliar with this - when we hit a callback condition, i.e. `condition = 0` we want the exact time where the event occured. As there is nothing like "exact" in floating point, we calculate time to be the previous nearest floating point time. But when we do this, we are actually going back in time. This could cause infinite loop of events. Right now, we use derivate to calculate the condition in some near future and use the value as the `prev_condition`. But this had failed too (Ref #207).
In this PR, I have added two few tweaks - 
1. Fixed epsilon handling in negetive dt case - because `max` function actually calculates the smaller step (magnitude wise) of the two in case of negetive dt.
2. Buggy time increment in of future. [here](https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/257/files#diff-f2ec50e45e2c0d098a69b4e7c72f86f3R434) if Bottom theta is not 0, then multiplying by 5 doesn't seem right to me. Though a rare case, it could be problematic when `dt` is small.

This needs to be merged with care. @ChrisRackauckas 