### PR TITLE
Generalize islinear

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -477,7 +477,7 @@ export initialize!
 
 export LinSolveFactorize, DEFAULT_LINSOLVE, LinSolveGMRES
 
-export AffineDiffEqOperator, update_coefficients!, update_coefficients, is_constant,
+export AffineDiffEqOperator, update_coefficients!, update_coefficients, isconstant,
        has_expmv!, has_expmv, has_exp, has_mul, has_mul!, has_ldiv, has_ldiv!
 
 export NLNewton, NLFunctional, NLAnderson

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -8,6 +8,7 @@ using LinearAlgebra
    update_coefficients!(A,u,p,t) that changes the internal coefficients, and a
    out-of-place form B = update_coefficients(A,u,p,t).
 3. is_constant(A) trait for whether the operator is constant or not.
+4. islinear(A) trait for whether the operator is linear or not.
 =#
 
 Base.eltype(L::AbstractDiffEqOperator{T}) where T = T
@@ -16,6 +17,7 @@ update_coefficients(L,u,p,t) = L
 
 # Traits
 is_constant(L::AbstractDiffEqOperator) = false
+islinear(::AbstractDiffEqOperator) = false
 has_expmv!(L::AbstractDiffEqOperator) = false # expmv!(v, L, t, u)
 has_expmv(L::AbstractDiffEqOperator) = false # v = exp(L, t, u)
 has_exp(L::AbstractDiffEqOperator) = false # v = exp(L, t)*u
@@ -43,6 +45,8 @@ has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 
 # Extra standard assumptions
 is_constant(L::AbstractDiffEqLinearOperator) = true
+islinear(::AbstractDiffEqLinearOperator) = true
+
 # Other ones from LinearMaps.jl
 # Generic fallbacks
 LinearAlgebra.exp(L::AbstractDiffEqLinearOperator,t) = exp(t*L)

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -2,8 +2,8 @@ using LinearAlgebra
 ### AbstractDiffEqOperator Interface
 
 #=
-1. Function call and multiplication: L(u,p,t,du) for inplace and du = L(u,p,t) for
-   out-of-place, meaning L*u and A_mul_B!.
+1. Function call and multiplication: L(du, u, p, t) for inplace and du = L(u, p, t) for
+   out-of-place, meaning L*u and mul!(du, L, u).
 2. If the operator is not a constant, update it with (u,p,t). A mutating form, i.e.
    update_coefficients!(A,u,p,t) that changes the internal coefficients, and a
    out-of-place form B = update_coefficients(A,u,p,t).
@@ -22,7 +22,7 @@ has_expmv!(L::AbstractDiffEqOperator) = false # expmv!(v, L, t, u)
 has_expmv(L::AbstractDiffEqOperator) = false # v = exp(L, t, u)
 has_exp(L::AbstractDiffEqOperator) = false # v = exp(L, t)*u
 has_mul(L::AbstractDiffEqOperator) = true # du = L*u
-has_mul!(L::AbstractDiffEqOperator) = false # A_mul_B!(du, L, u)
+has_mul!(L::AbstractDiffEqOperator) = false # mul!(du, L, u)
 has_ldiv(L::AbstractDiffEqOperator) = false # du = L\u
 has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 
@@ -52,7 +52,7 @@ islinear(::AbstractDiffEqLinearOperator) = true
 LinearAlgebra.exp(L::AbstractDiffEqLinearOperator,t) = exp(t*L)
 has_exp(L::AbstractDiffEqLinearOperator) = true
 expmv(L::AbstractDiffEqLinearOperator,u,p,t) = exp(L,t)*u
-expmv!(v,L::AbstractDiffEqLinearOperator,u,p,t) = A_mul_B!(v,exp(L,t),u)
+expmv!(v,L::AbstractDiffEqLinearOperator,u,p,t) = mul!(v,exp(L,t),u)
 # Factorizations have no fallback and just error
 
 """
@@ -66,10 +66,10 @@ Takes in two tuples for split Affine DiffEqs
 
 1. update_coefficients! works by updating the coefficients of the component
    operators.
-2. Function calls L(u,p,t) and L(u,p,t,du) are fallbacks interpretted in this form.
+2. Function calls L(u, p, t) and L(du, u, p, t) are fallbacks interpretted in this form.
    This will allow them to work directly in the nonlinear ODE solvers without
    modification.
-3. f(u,p,t,du) is only allowed if a u_cache is given
+3. f(du, u, p, t) is only allowed if a u_cache is given
 4. B(t) can be Union{Number,AbstractArray}, in which case they are constants.
    Otherwise they are interpreted they are functions v=B(t) and B(v,t)
 
@@ -104,8 +104,8 @@ function (L::AffineDiffEqOperator)(du,u,p,t::Number)
     fill!(du,zero(first(du)))
     # TODO: Make type-stable via recursion
     for A in L.As
-        A_mul_B!(u_cache,A,u)
         du .+= u_cache
+        mul!(du_cache,A,u)
     end
     for B in L.Bs
         if typeof(B) <: Union{Number,AbstractArray}

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -60,7 +60,7 @@ AffineDiffEqOperator{T} <: AbstractDiffEqOperator{T}
 
 `Ex: (A₁(t) + ... + Aₙ(t))*u + B₁(t) + ... + Bₙ(t)`
 
-AffineDiffEqOperator{T}(As,Bs,u_cache=nothing)
+AffineDiffEqOperator{T}(As,Bs,du_cache=nothing)
 
 Takes in two tuples for split Affine DiffEqs
 
@@ -69,7 +69,7 @@ Takes in two tuples for split Affine DiffEqs
 2. Function calls L(u, p, t) and L(du, u, p, t) are fallbacks interpretted in this form.
    This will allow them to work directly in the nonlinear ODE solvers without
    modification.
-3. f(du, u, p, t) is only allowed if a u_cache is given
+3. f(du, u, p, t) is only allowed if a du_cache is given
 4. B(t) can be Union{Number,AbstractArray}, in which case they are constants.
    Otherwise they are interpreted they are functions v=B(t) and B(v,t)
 
@@ -80,11 +80,11 @@ etc.
 struct AffineDiffEqOperator{T,T1,T2,U} <: AbstractDiffEqOperator{T}
     As::T1
     Bs::T2
-    u_cache::U
-    function AffineDiffEqOperator{T}(As,Bs,u_cache=nothing) where T
+    du_cache::U
+    function AffineDiffEqOperator{T}(As,Bs,du_cache=nothing) where T
         all([size(a) == size(As[1])
              for a in As]) || error("Operator sizes do not agree")
-        new{T,typeof(As),typeof(Bs),typeof(u_cache)}(As,Bs,u_cache)
+        new{T,typeof(As),typeof(Bs),typeof(du_cache)}(As,Bs,du_cache)
     end
 end
 
@@ -99,20 +99,20 @@ end
 
 function (L::AffineDiffEqOperator)(du,u,p,t::Number)
     update_coefficients!(L,u,p,t)
-    L.u_cache == nothing && error("Can only use inplace AffineDiffEqOperator if u_cache is given.")
-    u_cache = L.u_cache
+    L.du_cache == nothing && error("Can only use inplace AffineDiffEqOperator if du_cache is given.")
+    du_cache = L.du_cache
     fill!(du,zero(first(du)))
     # TODO: Make type-stable via recursion
     for A in L.As
-        du .+= u_cache
         mul!(du_cache,A,u)
+        du .+= du_cache
     end
     for B in L.Bs
         if typeof(B) <: Union{Number,AbstractArray}
             du .+= B
         else
-            B(u_cache,t)
-            du .+= u_cache
+            B(du_cache,t)
+            du .+= du_cache
         end
     end
 end

--- a/src/diffeq_operator.jl
+++ b/src/diffeq_operator.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
 2. If the operator is not a constant, update it with (u,p,t). A mutating form, i.e.
    update_coefficients!(A,u,p,t) that changes the internal coefficients, and a
    out-of-place form B = update_coefficients(A,u,p,t).
-3. is_constant(A) trait for whether the operator is constant or not.
+3. isconstant(A) trait for whether the operator is constant or not.
 4. islinear(A) trait for whether the operator is linear or not.
 =#
 
@@ -16,7 +16,7 @@ update_coefficients!(L,u,p,t) = nothing
 update_coefficients(L,u,p,t) = L
 
 # Traits
-is_constant(L::AbstractDiffEqOperator) = false
+isconstant(::AbstractDiffEqOperator) = false
 islinear(::AbstractDiffEqOperator) = false
 has_expmv!(L::AbstractDiffEqOperator) = false # expmv!(v, L, t, u)
 has_expmv(L::AbstractDiffEqOperator) = false # v = exp(L, t, u)
@@ -44,7 +44,7 @@ has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 =#
 
 # Extra standard assumptions
-is_constant(L::AbstractDiffEqLinearOperator) = true
+isconstant(::AbstractDiffEqLinearOperator) = true
 islinear(::AbstractDiffEqLinearOperator) = true
 
 # Other ones from LinearMaps.jl
@@ -74,7 +74,7 @@ Takes in two tuples for split Affine DiffEqs
    Otherwise they are interpreted they are functions v=B(t) and B(v,t)
 
 Solvers will see this operator from integrator.f and can interpret it by
-checking the internals of As and Bs. For example, it can check is_constant(As[1])
+checking the internals of As and Bs. For example, it can check isconstant(As[1])
 etc.
 """
 struct AffineDiffEqOperator{T,T1,T2,U} <: AbstractDiffEqOperator{T}
@@ -122,3 +122,5 @@ function update_coefficients!(L::AffineDiffEqOperator,u,p,t)
     for A in L.As; update_coefficients!(A,u,p,t); end
     for B in L.Bs; update_coefficients!(B,u,p,t); end
 end
+
+@deprecate is_constant(L::AbstractDiffEqOperator) isconstant(L)

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -589,6 +589,12 @@ has_invW_t(f::DynamicalODEFunction) = has_invW_t(f.f1)
 has_paramjac(f::DynamicalODEFunction) = has_paramjac(f.f1)
 has_colorvec(f::DynamicalODEFunction) = has_colorvec(f.f1)
 
+######### Additional traits
+
+islinear(::AbstractDiffEqFunction) = false
+islinear(f::ODEFunction) = islinear(f.f)
+islinear(f::SplitFunction) = islinear(f.f1)
+
 ######### Compatibility Constructor from Tratis
 
 ODEFunction{iip}(f::T) where {iip,T} = return T<:ODEFunction ? f : convert(ODEFunction{iip},f)

--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -591,6 +591,7 @@ has_colorvec(f::DynamicalODEFunction) = has_colorvec(f.f1)
 
 ######### Additional traits
 
+islinear(f) = false # fallback
 islinear(::AbstractDiffEqFunction) = false
 islinear(f::ODEFunction) = islinear(f.f)
 islinear(f::SplitFunction) = islinear(f.f1)

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -144,7 +144,7 @@ DiffEqBase.@def iipnlsolve begin
   # define additional fields of cache
   fsalfirst = zero(rate_prototype)
   if alg.nlsolve isa NLNewton
-    if islinear(nf)
+    if islinear(f)
       du1 = rate_prototype
       uf = nothing
       jac_config = nothing

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -107,10 +107,7 @@ DiffEqBase.@def iipnlsolve begin
   if alg.nlsolve isa NLNewton
     nf = nlsolve_f(f, alg)
 
-    # check if `nf` is linear
-    islin = f isa Union{ODEFunction,SplitFunction} && islinear(nf.f)
-
-    if islin
+    if islinear(f)
       # get the operator
       J = nf.f
       W = WOperator(f.mass_matrix, dt, J, true)
@@ -146,7 +143,7 @@ DiffEqBase.@def iipnlsolve begin
   # define additional fields of cache
   fsalfirst = zero(rate_prototype)
   if alg.nlsolve isa NLNewton
-    if islin
+    if islinear(nf)
       du1 = rate_prototype
       uf = nothing
       jac_config = nothing
@@ -189,10 +186,9 @@ DiffEqBase.@def oopnlsolve begin
     # only use `nf` if the algorithm specializes on split eqs
     uf = DiffEqDiffTools.UDerivativeWrapper(nf,t,p)
 
-    islin = f isa Union{ODEFunction,SplitFunction} && islinear(nf.f)
-    if islin || DiffEqBase.has_jac(f)
+    if islinear(f) || DiffEqBase.has_jac(f)
       # get the operator
-      J = islin ? nf.f : f.jac(uprev, p, t)
+      J = islinear(f) ? nf.f : f.jac(uprev, p, t)
       if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
         J = DiffEqArrayOperator(J)
       end
@@ -270,8 +266,8 @@ function iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottom
   # define additional fields of cache
   if alg.nlsolve isa NLNewton
     nf = nlsolve_f(f, alg)
-    islin = f isa Union{ODEFunction,SplitFunction} && islinear(nf.f)
-    if islin
+
+    if islinear(f)
       du1 = rate_prototype
       uf = nothing
       jac_config = nothing

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -354,7 +354,7 @@ function nlsolve_resize!(integrator::DEIntegrator, i::Int)
       resize!(ztmp,i)
       resize!(k,i)
       resize!(du1,i)
-      if jac_config != nothing
+      if jac_config !== nothing
         _nlsolver.jac_config = resize_jac_config!(jac_config, uf, du1, z, alg, i)
         integrator.cache.jac_config[idx] = _nlsolver.jac_config
       end
@@ -372,7 +372,7 @@ function nlsolve_resize!(integrator::DEIntegrator, i::Int)
     resize!(ztmp,i)
     resize!(k,i)
     resize!(du1,i)
-    if jac_config != nothing
+    if jac_config !== nothing
       nlsolver.jac_config = resize_jac_config!(jac_config, uf, du1, z, alg, i)
       integrator.cache.jac_config = nlsolver.jac_config
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -197,8 +197,6 @@ _vec(v::AbstractVector) = v
 _reshape(v, siz) = reshape(v, siz)
 _reshape(v::Number, siz) = v
 
-islinear(f) = f isa AbstractDiffEqLinearOperator && is_constant(f)
-
 macro tight_loop_macros(ex)
    :($(esc(ex)))
 end


### PR DESCRIPTION
This PR generalizes islinear to DiffEqFunctions. Moreover, I updated some outdated documentation of DiffEqOperators and replaced some calls of `A_mul_B!`.

The last two commits are not needed, but I think the name `du_cache` is a bit more appropriate and for consistency with Base and `islinear` `is_constant` could be replaced with `isconstant`.