### PR TITLE
add LinSolveGPUFactorize

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -1,4 +1,5 @@
 value(x) = x
+cuify(x) = error("To use LinSolveGPUFactorize, you must do `using CuArrays`")
 
 function __init__()
   @require ApproxFun="28f2ccd6-bb30-5033-b560-165f7b14dc2f" begin
@@ -114,10 +115,10 @@ function __init__()
 
   # Piracy, should get upstreamed
   @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
+    cuify(x::AbstractArray) = CuArrays.CuArray(x)
     function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
       _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
       x .= vec(_x)
     end
   end
-
 end


### PR DESCRIPTION
Auto-GPU linear solver usage. Allows for big linear solves to be GPU-accelerated even if the function is not amenable to GPU usage.

```julia
using OrdinaryDiffEq, ParameterizedFunctions

f = @ode_def Hires begin
  dy1 = -1.71*y1 + 0.43*y2 + 8.32*y3 + 0.0007
  dy2 = 1.71*y1 - 8.75*y2
  dy3 = -10.03*y3 + 0.43*y4 + 0.035*y5
  dy4 = 8.32*y2 + 1.71*y3 - 1.12*y4
  dy5 = -1.745*y5 + 0.43*y6 + 0.43*y7
  dy6 = -280.0*y6*y8 + 0.69*y4 + 1.71*y5 -
           0.43*y6 + 0.69*y7
  dy7 = 280.0*y6*y8 - 1.81*y7
  dy8 = -280.0*y6*y8 + 1.81*y7
end

u0 = zeros(8)
u0[1] = 1
u0[8] = 0.0057
prob = ODEProblem(f,u0,(0.0,321.8122))

using CuArrays
sol = solve(prob,Rodas5(linsolve=DiffEqBase.LinSolveGPUFactorize()),
                        abstol=1/10^14,reltol=1/10^14)
```