### PR TITLE
Add order_discontinuity_t0 to DDEProblem

### DIFF
--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -9,22 +9,19 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
   dependent_lags::lType2
   callback::C
   neutral::Bool
-  @add_kwonly function DDEProblem{iip}(f::AbstractDDEFunction{iip},
-                                 u0,h,tspan,p=nothing;
-                                 constant_lags=[],
-                                 dependent_lags=[],
-                                 neutral = f.mass_matrix == I ?
-                                           false : det(f.mass_matrix)!=1,
-                                 callback = nothing) where {iip}
+  order_discontinuity_t0::Int
+
+  @add_kwonly function DDEProblem{iip}(f::AbstractDDEFunction{iip}, u0, h, tspan, p=nothing;
+                                       constant_lags=[],
+                                       dependent_lags=[],
+                                       neutral = f.mass_matrix !== I && det(f.mass_matrix) != 1,
+                                       order_discontinuity_t0 = 0,
+                                       callback = nothing) where {iip}
     _tspan = promote_tspan(tspan)
-    new{typeof(u0),typeof(_tspan),
-               typeof(constant_lags),typeof(dependent_lags),
-               isinplace(f),typeof(p),
-               typeof(f),typeof(h),typeof(callback)
-               }(f,u0,h,_tspan,p,
-                 constant_lags,
-                 dependent_lags,callback,
-                 neutral)
+    new{typeof(u0),typeof(_tspan),typeof(constant_lags),typeof(dependent_lags),isinplace(f),
+        typeof(p),typeof(f),typeof(h),typeof(callback)}(
+          f, u0, h, _tspan, p, constant_lags, dependent_lags, callback, neutral,
+          order_discontinuity_t0)
   end
 
   function DDEProblem{iip}(f,u0,h,tspan,p=nothing;kwargs...) where {iip}


### PR DESCRIPTION
As mentioned in https://github.com/JuliaDiffEq/DiffEqProblemLibrary.jl/pull/39#issue-293098398, the order of the discontinuity at the initial time point for DDEs is a property of the problem (more precisely, the combination of `u0`, `t0`, and `h`). Hence I think it should be added to `DDEProblem` and not be provided as a keyword argument to `solve`.