### PR TITLE
Fix missed callback

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -265,7 +265,7 @@ end
   next_sign = @view(integrator.callback_cache.next_sign[1:callback.len])
 
 
-  if integrator.event_last_time == counter && minimum(ODE_DEFAULT_NORM(previous_condition[ivec],integrator.t)) < 100ODE_DEFAULT_NORM(integrator.last_event_error,integrator.t)
+  if integrator.event_last_time == counter && minimum(ODE_DEFAULT_NORM(previous_condition[ivec],integrator.t)) <= 100ODE_DEFAULT_NORM(integrator.last_event_error,integrator.t)
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then
@@ -343,7 +343,7 @@ end
   prev_sign = 0.0
   next_sign = 0.0
 
-  if integrator.event_last_time == counter && minimum(ODE_DEFAULT_NORM(previous_condition,integrator.t)) < 100ODE_DEFAULT_NORM(integrator.last_event_error,integrator.t)
+  if integrator.event_last_time == counter && minimum(ODE_DEFAULT_NORM(previous_condition,integrator.t)) <= 100ODE_DEFAULT_NORM(integrator.last_event_error,integrator.t)
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -347,8 +347,8 @@ end
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then
-    # we treat the value as positive, and derivative is negative then we
-    # treat the value as negative, reguardless of the postiivity/negativity
+    # we treat `prev_sign` as negetive, and if the derivative is negative then we
+    # treat `prev_sign` as positive, regardless of the postiivity/negativity
     # of the true value due to it being =0 sans floating point issues.
 
     # Only due this if the discontinuity did not move it far away from an event

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -269,8 +269,8 @@ end
 
     # If there was a previous event, utilize the derivative at the start to
     # chose the previous sign. If the derivative is positive at tprev, then
-    # we treat the value as positive, and derivative is negative then we
-    # treat the value as negative, reguardless of the postiivity/negativity
+    # we treat `prev_sign` as negetive, and if the derivative is negative then we
+    # treat `prev_sign` as positive, regardless of the postiivity/negativity
     # of the true value due to it being =0 sans floating point issues.
 
     # Only due this if the discontinuity did not move it far away from an event


### PR DESCRIPTION
Fixes #266. Actually the problem was that by default `event_last_error` is set to zero. When an event occurs at any timesteps, we do not update `event_last_error` (see [here](https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/master/src/callbacks.jl#L421)) So as long as the first non-timstep callback occurs, `event_last_error` is zero, hence the code wont enter [here](https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/master/src/callbacks.jl#L346) even if the `prev_condition` was zero. Therefore the callback got missed as we didn't calculate prev_sign in near future.

This code used to throw only a single ping, but is fixed in the branch -
```julia
using OrdinaryDiffEq
function f(u,p,t)
  u
end

condition(u,t,integrator) = (t - 0.5)*(t - 0.6)
affect!(integrator) = println("ping")
cb = ContinuousCallback(condition,affect!)
u0 = 1.0
tspan = (0.0,1.0)
prob = ODEProblem(f,u0,tspan)
sol = solve(prob,Tsit5(),callback=cb,dt=0.1,adaptive=false)
```

@tomaklutfu Please see if this branch fixes your issue. 
@ChrisRackauckas I hope that changing `<` with `<=` won't cause any accuracy issue because of increase of range.