### PR TITLE
[WIP] Make nlsolve thread safe

### DIFF
--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -161,7 +161,7 @@ end
       @.. u = uprev+z
       update_coefficients!(W,u,p,tstep)
     end
-    cache.linsolve(vecdz,W,vecztmp,iter == 1 && new_W; Pl=ScaleVector(weight, true), Pr=ScaleVector(weight, false), tol=lintol)
+    nlsolver.linsolve(vecdz,W,vecztmp,iter == 1 && new_W; Pl=ScaleVector(weight, true), Pr=ScaleVector(weight, false), tol=lintol)
 
     if has_destats(integrator)
       integrator.destats.nsolve += 1

--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -145,8 +145,8 @@ end
     end
 
     # evaluate function
-    @.. u = tmp + γ*z
-    f(k, u, p, tstep)
+    @.. dz = tmp + γ*z
+    f(k, dz, p, tstep)
     if has_destats(integrator)
       integrator.destats.nf += 1
     end
@@ -158,8 +158,8 @@ end
     end
     
     if W isa AbstractDiffEqLinearOperator
-      @.. u = uprev+z
-      update_coefficients!(W,u,p,tstep)
+      @.. dz = uprev+z
+      update_coefficients!(W,dz,p,tstep)
     end
     nlsolver.linsolve(vecdz,W,vecztmp,iter == 1 && new_W; Pl=ScaleVector(weight, true), Pr=ScaleVector(weight, false), tol=lintol)
 

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -66,15 +66,17 @@ NLNewton(; κ=1//100, max_iter=10, fast_convergence_cutoff=1//5, new_W_dt_cutoff
 
 # caches
 
-mutable struct NLNewtonCache{W,T,C} <: AbstractNLSolverCache
+mutable struct NLNewtonCache{W,J,T,C} <: AbstractNLSolverCache
   new_W::Bool
   W::W
+  J::J
   W_dt::T
   new_W_dt_cutoff::C
 end
 
-mutable struct NLNewtonConstantCache{W,C} <: AbstractNLSolverCache
+mutable struct NLNewtonConstantCache{W,J,C} <: AbstractNLSolverCache
   W::W
+  J::J
   new_W_dt_cutoff::C
 end
 

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -122,7 +122,7 @@ DiffEqBase.@def iipnlsolve begin
       end
     end
 
-    nlcache = DiffEqBase.NLNewtonCache(true,W,dt,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonCache(true,W,J,dt,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     z₊ = similar(z)
 
@@ -213,7 +213,7 @@ DiffEqBase.@def oopnlsolve begin
       end
     end
 
-    nlcache = DiffEqBase.NLNewtonConstantCache(W,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonConstantCache(W,J,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     uf = nothing
 
@@ -234,7 +234,12 @@ DiffEqBase.@def oopnlsolve begin
   nlsolver = NLSolver{false,typeof(z),typeof(k),uTolType,typeof(κ),typeof(γ),typeof(c),Nothing,typeof(uf),Nothing,Nothing,typeof(fast_convergence_cutoff),typeof(nlcache)}(z,dz,tmp,b,k,one(uTolType),κ,γ,c,alg.nlsolve.max_iter,10000,Convergence,fast_convergence_cutoff,nothing,uf,nothing,nothing,z,nlcache)
 end
 
+# No J version
 function iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  iipnlsolve(alg,u,uprev,p,t,dt,f,W,nothing,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+end
+
+function iipnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @unpack κ, fast_convergence_cutoff = alg.nlsolve
 
   # define additional fields of cache of non-linear solver
@@ -245,7 +250,7 @@ function iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottom
 
   # create cache of non-linear solver
   if alg.nlsolve isa NLNewton
-    nlcache = DiffEqBase.NLNewtonCache(true,W,dt,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonCache(true,W,J,dt,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     z₊ = similar(z)
 
@@ -301,7 +306,12 @@ DiffEqBase.@def getiipnlsolvefields begin
   fsalfirst = zero(rate_prototype)
 end
 
+# No J version
 function oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  oopnlsolve(alg,u,uprev,p,t,dt,f,W,nothing,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)  
+end
+
+function oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @unpack κ, fast_convergence_cutoff = alg.nlsolve
 
   # define additional fields of cache of non-linear solver (all aliased)
@@ -314,7 +324,7 @@ function oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottom
     nf = nlsolve_f(f, alg)
     # only use `nf` if the algorithm specializes on split eqs
     uf = oop_get_uf(alg,nf,t,p)
-    nlcache = DiffEqBase.NLNewtonConstantCache(W,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonConstantCache(W,J,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     uf = nothing
     nlcache = DiffEqBase.NLFunctionalConstantCache()


### PR DESCRIPTION
For this to be thread safe, we need to not edit any values from integrator. Right now we use `u` from integrator hence this is not thread safe. And having an extra `tmp_u` would hit all the other solvers. Should we have a new custom `ThreadedNLSolver`? This has 2 benefits, first - we don't play around the previously stable methods hence not breaking them. Secondly - we can have higher customization for such NLSolver, because in parallel methods, it's not necessary that you have 5 different `W` for 5 different threads.