### PR TITLE
No need of J in NLNewtonConstantCache

### DIFF
--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -74,9 +74,8 @@ mutable struct NLNewtonCache{W,J,T,C} <: AbstractNLSolverCache
   new_W_dt_cutoff::C
 end
 
-mutable struct NLNewtonConstantCache{W,J,C} <: AbstractNLSolverCache
+mutable struct NLNewtonConstantCache{W,C} <: AbstractNLSolverCache
   W::W
-  J::J
   new_W_dt_cutoff::C
 end
 

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -213,7 +213,7 @@ DiffEqBase.@def oopnlsolve begin
       end
     end
 
-    nlcache = DiffEqBase.NLNewtonConstantCache(W,J,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonConstantCache(W,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     uf = nothing
 
@@ -306,12 +306,7 @@ DiffEqBase.@def getiipnlsolvefields begin
   fsalfirst = zero(rate_prototype)
 end
 
-# No J version
 function oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
-  oopnlsolve(alg,u,uprev,p,t,dt,f,W,nothing,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)  
-end
-
-function oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
   @unpack κ, fast_convergence_cutoff = alg.nlsolve
 
   # define additional fields of cache of non-linear solver (all aliased)
@@ -324,7 +319,7 @@ function oopnlsolve(alg,u,uprev,p,t,dt,f,W,J,rate_prototype,uEltypeNoUnits,uBott
     nf = nlsolve_f(f, alg)
     # only use `nf` if the algorithm specializes on split eqs
     uf = oop_get_uf(alg,nf,t,p)
-    nlcache = DiffEqBase.NLNewtonConstantCache(W,J,alg.nlsolve.new_W_dt_cutoff)
+    nlcache = DiffEqBase.NLNewtonConstantCache(W,alg.nlsolve.new_W_dt_cutoff)
   elseif alg.nlsolve isa NLFunctional
     uf = nothing
     nlcache = DiffEqBase.NLFunctionalConstantCache()


### PR DESCRIPTION
Continuation of #288 I missed this fact. Testing OrdinaryDiffEq before merging.