### PR TITLE
fix failing OrdinaryDiffEq tests

### DIFF
--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -156,9 +156,8 @@ end
       mul!(vecztmp,mass_matrix,vecz)
       @.. ztmp = (dt*k - ztmp) * invγdt
     end
-    
+
     if W isa AbstractDiffEqLinearOperator
-      @.. dz = uprev+z
       update_coefficients!(W,dz,p,tstep)
     end
     nlsolver.linsolve(vecdz,W,vecztmp,iter == 1 && new_W; Pl=ScaleVector(weight, true), Pr=ScaleVector(weight, false), tol=lintol)
@@ -170,7 +169,8 @@ end
     # compute norm of residuals
     iter > 1 && (ndzprev = ndz)
     #W_dt != dt && (rmul!(dz, 2/(1 + dt / W_dt))) # relaxation
-    calculate_residuals!(ztmp, dz, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
+    @.. ztmp = tmp + γ*z
+    calculate_residuals!(ztmp, dz, uprev, ztmp, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
     ndz = integrator.opts.internalnorm(ztmp, t)
 
     # check divergence (not in initial step)


### PR DESCRIPTION
@kanav99 @YingboMa this is one that needs more looking into. @devmotion this could cause the differences we noticed in iip vs oop, and it was caught by an OrdinaryDiffEq test

https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/test/integrators/integrator_interface_tests.jl#L6-L41

The issue was 

https://github.com/JuliaDiffEq/DiffEqBase.jl/compare/possible_fix?expand=1#diff-305950d2ce3e1263c689b30816f31933R173

The reason was because the `u` in the residuals was updating every step, so I changed it to just do it the thread-safe way. However, this raises a question: should we use the updated value of `u` in the residual each time? If we want to change it, we should change both iip and oop, not just one. If there's a bad iterate, using a higher `max` would reduce the effect of the relative tolerance. Likely, it's not something that really matters, but is just a choice, but it's one to benchmark.

The second thing was that 

https://github.com/JuliaDiffEq/DiffEqBase.jl/compare/possible_fix?expand=1#diff-305950d2ce3e1263c689b30816f31933R161

was updating to the wrong coefficient since `@.. dz = uprev+z` was not the approximation of `u`, rather `@.. dz = uprev+γ*z`. This could be causing some of our GMRES issues.