### PR TITLE
Do not evaluate u0 at problem creation and make p keyword

### DIFF
--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -11,7 +11,8 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
   neutral::Bool
   order_discontinuity_t0::Int
 
-  @add_kwonly function DDEProblem{iip}(f::AbstractDDEFunction{iip}, u0, h, tspan, p = nothing;
+  @add_kwonly function DDEProblem{iip}(f::AbstractDDEFunction{iip}, u0, h, tspan;
+                                       p = nothing,
                                        constant_lags = (),
                                        dependent_lags = (),
                                        neutral = f.mass_matrix !== I && det(f.mass_matrix) != 1,
@@ -24,9 +25,9 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
           order_discontinuity_t0)
   end
 
-  function DDEProblem{iip}(f::AbstractDDEFunction{iip}, h, tspan::Tuple, p = nothing;
+  function DDEProblem{iip}(f::AbstractDDEFunction{iip}, h, tspan;
                            order_discontinuity_t0 = 1, kwargs...) where iip
-    DDEProblem{iip}(f, h(p, first(tspan)), h, tspan, p;
+    DDEProblem{iip}(f, h, h, tspan;
                     order_discontinuity_t0 = max(1, order_discontinuity_t0), kwargs...)
   end
 
@@ -40,3 +41,6 @@ DDEProblem(f, args...; kwargs...) =
 
 DDEProblem(f::AbstractDDEFunction, args...; kwargs...) =
   DDEProblem{isinplace(f)}(f, args...; kwargs...)
+
+@deprecate DDEProblem{iip}(f, u0, h, tspan, p; kwargs...) where iip DDEProblem{iip}(f, u0, h, tspan; p = p, kwargs...)
+@deprecate DDEProblem(f, u0, h, tspan, p; kwargs...) DDEProblem(f, u0, h, tspan; p = p, kwargs...)

--- a/test/high_level_solve.jl
+++ b/test/high_level_solve.jl
@@ -23,9 +23,19 @@ prob = ODEProblem((u,p,t)->u,1.0,(0,1))
             "instead of (0,1).") DiffEqBase.adaptive_warn(prob.u0,prob.tspan)
 
 prob = DDEProblem((u, h, p, t) -> - h(p, t - p[1]), (p, t0) -> p[2], (p, t) -> 0,
-                  (p) -> (0.0, p[3]), (1.0, 2.0, 3.0); constant_lags = (p) -> [p[1]])
+                  p -> (0.0, p[3]);
+                  p = (1.0, 2.0, 3.0), constant_lags = p -> [p[1]])
 prob2 = DiffEqBase.get_concrete_problem(prob, nothing)
 
+@test prob2.u0 == 2.0
+@test prob2.tspan == (0.0, 3.0)
+@test prob2.constant_lags == [1.0]
+
+prob = DDEProblem((u, h, p, t) -> - h(p, t - p[1]), (p, t) -> p[2], p -> (0.0, p[3]);
+                  p = (1.0, 2.0, 3.0), constant_lags = p -> [p[1]])
+prob2 = DiffEqBase.get_concrete_problem(prob, nothing)
+
+@test prob.u0 isa Function
 @test prob2.u0 == 2.0
 @test prob2.tspan == (0.0, 3.0)
 @test prob2.constant_lags == [1.0]

--- a/test/problem_creation_tests.jl
+++ b/test/problem_creation_tests.jl
@@ -54,6 +54,10 @@ prob =  DDEProblem{true}(f_1delay,ones(1),t->zeros(1),(0.0, 10.0),dependent_lags
 
 @test_broken @inferred DDEProblem(f_1delay,ones(1),t->zeros(1),(0.0, 10.0),constant_lags = ones(1))
 @test_broken @inferred DDEProblem{true}(f_1delay,ones(1),t->zeros(1),(0.0, 10.0),dependent_lags = ones(1))
+@test_deprecated DDEProblem(f_1delay, ones(1), t->zeros(1), (0.0, 10.0), nothing;
+                            constant_lags = ones(1))
+@test_deprecated DDEProblem{true}(f_1delay, ones(1), t->zeros(1), (0.0, 10.0), nothing;
+                                  constant_lags = ones(1))
 
 function f(r, yp, y, p,tres)
     r[1]  = -0.04*y[1] + 1.0e4*y[2]*y[3]


### PR DESCRIPTION
I just noticed that it's a bit weird that we compute `u0` when a problem is created for which only `h` is specified. IMO it's more reasonable to just assign `u0 = h` and compute the concrete `u0` only when we compute a solution. By letting `u0` be a function, it will be updated automatically if a change in the parameters affects the history function.

Moreover, I noticed that the current approach of dispatching on `tspan::Tuple` does not allow to specify both only `h` and a function for `tspan`. It seems we can resolve this problem by making `p` a keyword argument instead of an optional argument. However, I'm not sure if that's something we actually want to do. If it's OK, we should maybe handle parameters in other problem types in the same way for consistency. I added a deprecation warning for backward compatibility.