### PR TITLE
Capture kwargs in problem construction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.20.1"
+version = "6.0.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -1,14 +1,14 @@
-struct AnalyticalProblem{uType,tType,isinplace,P,F,C} <: AbstractAnalyticalProblem{uType,tType,isinplace}
+struct AnalyticalProblem{uType,tType,isinplace,P,F,K} <: AbstractAnalyticalProblem{uType,tType,isinplace}
   f::F
   u0::uType
   tspan::tType
   p::P
-  callback::C
+  kwargs::K
   @add_kwonly function AnalyticalProblem{iip}(f,u0,tspan,p=NullParameters();
-           callback = nothing) where {iip}
+           kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),iip,typeof(p),
-        typeof(f),typeof(callback)}(f,u0,_tspan,p,callback)
+        typeof(f),typeof(kwargs)}(f,u0,_tspan,p,kwargs)
   end
 end
 

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -1,22 +1,22 @@
 struct StandardBVProblem end
 
-struct BVProblem{uType,tType,isinplace,P,F,bF,PT,CB} <: AbstractBVProblem{uType,tType,isinplace}
+struct BVProblem{uType,tType,isinplace,P,F,bF,PT,K} <: AbstractBVProblem{uType,tType,isinplace}
     f::F
     bc::bF
     u0::uType
     tspan::tType
     p::P
     problem_type::PT
-    callback::CB
+    kwargs::K
     @add_kwonly function BVProblem{iip}(f::AbstractODEFunction,bc,u0,tspan,p=NullParameters(),
                             problem_type=StandardBVProblem();
-                            callback=nothing) where {iip}
+                            kwargs...) where {iip}
         _tspan = promote_tspan(tspan)
         new{typeof(u0),typeof(tspan),iip,typeof(p),
                   typeof(f),typeof(bc),
-                  typeof(problem_type),typeof(callback)}(
+                  typeof(problem_type),typeof(kwargs)}(
                   f,bc,u0,_tspan,p,
-                  problem_type,callback)
+                  problem_type,kwargs)
     end
 
     function BVProblem{iip}(f,bc,u0,tspan,p=NullParameters();kwargs...) where {iip}

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -1,23 +1,23 @@
 # f(t,u,du,res) = 0
-struct DAEProblem{uType,duType,tType,isinplace,P,F,C,D} <: AbstractDAEProblem{uType,duType,tType,isinplace}
+struct DAEProblem{uType,duType,tType,isinplace,P,F,K,D} <: AbstractDAEProblem{uType,duType,tType,isinplace}
   f::F
   du0::duType
   u0::uType
   tspan::tType
   p::P
-  callback::C
+  kwargs::K
   differential_vars::D
   @add_kwonly function DAEProblem{iip}(f::AbstractDAEFunction{iip},
                       du0,u0,tspan,p=NullParameters();
-                      callback = nothing,
-                      differential_vars = nothing) where {iip}
+                      differential_vars = nothing,
+                      kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(du0),typeof(_tspan),
                isinplace(f),typeof(p),
-               typeof(f),typeof(callback),
+               typeof(f),typeof(kwargs),
                typeof(differential_vars)}(
                f,du0,u0,_tspan,p,
-               callback,differential_vars)
+               kwargs,differential_vars)
   end
 
   function DAEProblem{iip}(f,du0,u0,tspan,p=NullParameters();kwargs...) where {iip}

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -1,4 +1,4 @@
-struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
+struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,K} <:
                           AbstractDDEProblem{uType,tType,lType,isinplace}
   f::F
   u0::uType
@@ -7,7 +7,7 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
   p::P
   constant_lags::lType
   dependent_lags::lType2
-  callback::C
+  kwargs::K
   neutral::Bool
   order_discontinuity_t0::Int
 
@@ -16,11 +16,11 @@ struct DDEProblem{uType,tType,lType,lType2,isinplace,P,F,H,C} <:
                                        dependent_lags = (),
                                        neutral = f.mass_matrix !== I && det(f.mass_matrix) != 1,
                                        order_discontinuity_t0 = 0,
-                                       callback = nothing) where {iip}
+                                       kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),typeof(constant_lags),typeof(dependent_lags),isinplace(f),
-        typeof(p),typeof(f),typeof(h),typeof(callback)}(
-          f, u0, h, _tspan, p, constant_lags, dependent_lags, callback, neutral,
+        typeof(p),typeof(f),typeof(h),typeof(kwargs)}(
+          f, u0, h, _tspan, p, constant_lags, dependent_lags, kwargs, neutral,
           order_discontinuity_t0)
   end
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -10,7 +10,7 @@ Defines a discrete problem.
 
 $(FIELDS)
 """
-struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{uType,tType,isinplace}
+struct DiscreteProblem{uType,tType,isinplace,P,F,K} <: AbstractDiscreteProblem{uType,tType,isinplace}
   """The function in the map."""
   f::F
   """The initial condition."""
@@ -20,14 +20,14 @@ struct DiscreteProblem{uType,tType,isinplace,P,F,C} <: AbstractDiscreteProblem{u
   """The parameter values of the function."""
   p::P
   """ A callback to be applied to every solver which uses the problem."""
-  callback::C
+  kwargs::K
   @add_kwonly function DiscreteProblem{iip}(f::AbstractDiscreteFunction{iip},
                                             u0,tspan::Tuple,p=NullParameters();
-                                            callback = nothing) where {iip}
+                                            kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),isinplace(f,4),
         typeof(p),
-        typeof(f),typeof(callback)}(f,u0,_tspan,p,callback)
+        typeof(f),typeof(kwargs)}(f,u0,_tspan,p,kwargs)
   end
 
   function DiscreteProblem{iip}(u0::Nothing,tspan::Nothing,p=NullParameters();

--- a/src/problems/noise_problems.jl
+++ b/src/problems/noise_problems.jl
@@ -1,10 +1,11 @@
-struct NoiseProblem{N<:AbstractNoiseProcess,T} <: AbstractNoiseProblem
+struct NoiseProblem{N<:AbstractNoiseProcess,T,K} <: AbstractNoiseProblem
   noise::N
   tspan::T
   seed::UInt64
+  kwargs::K
 end
 
-@add_kwonly function NoiseProblem(noise,tspan;seed=UInt64(0))
+@add_kwonly function NoiseProblem(noise,tspan;seed=UInt64(0),kwargs...)
   _tspan = promote_tspan(tspan)
-  NoiseProblem{typeof(noise),typeof(_tspan)}(noise,_tspan,seed)
+  NoiseProblem{typeof(noise),typeof(_tspan),typeof(kwargs)}(noise,_tspan,seed,kwargs)
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -15,7 +15,7 @@ Defines an ODE problem.
 
 $(FIELDS)
 """
-struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
+struct ODEProblem{uType,tType,isinplace,P,F,K,PT} <:
                AbstractODEProblem{uType,tType,isinplace}
   """The function in the ODE."""
   f::F
@@ -26,19 +26,19 @@ struct ODEProblem{uType,tType,isinplace,P,F,C,PT} <:
   """The parameter values of the ODE function."""
   p::P
   """A callback to be applied to every solver which uses the problem."""
-  callback::C
+  kwargs::K
   """TODO"""
   problem_type::PT
   @add_kwonly function ODEProblem{iip}(f::AbstractODEFunction{iip},
                                        u0,tspan,p=NullParameters(),
                                        problem_type=StandardODEProblem();
-                                       callback=nothing) where {iip}
+                                       kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(_tspan),
        isinplace(f),typeof(p),typeof(f),
-       typeof(callback),
+       typeof(kwargs),
        typeof(problem_type)}(
-       f,u0,_tspan,p,callback,problem_type)
+       f,u0,_tspan,p,kwargs,problem_type)
   end
 
   """

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,22 +1,22 @@
-mutable struct RODEProblem{uType,tType,isinplace,P,NP,F,C,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
+mutable struct RODEProblem{uType,tType,isinplace,P,NP,F,K,ND} <: AbstractRODEProblem{uType,tType,isinplace,ND}
   f::F
   u0::uType
   tspan::tType
   p::P
   noise::NP
-  callback::C
+  kwargs::K
   rand_prototype::ND
   seed::UInt64
   @add_kwonly function RODEProblem{iip}(f::RODEFunction{iip},u0,tspan,p=NullParameters();
                        rand_prototype = nothing,
                        noise= nothing, seed = UInt64(0),
-                       callback=nothing) where {iip}
+                       kwargs...) where {iip}
   _tspan = promote_tspan(tspan)
   new{typeof(u0),typeof(_tspan),
               isinplace(f),typeof(p),
-              typeof(noise),typeof(f),typeof(callback),
+              typeof(noise),typeof(f),typeof(kwargs),
               typeof(rand_prototype)}(
-              f,u0,_tspan,p,noise,callback,
+              f,u0,_tspan,p,noise,kwargs,
               rand_prototype,seed)
   end
   function RODEProblem{iip}(f,u0,tspan,p=NullParameters();kwargs...) where {iip}

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -1,29 +1,29 @@
 struct StandardSDEProblem end
 
-struct SDEProblem{uType,tType,isinplace,P,NP,F,G,C,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
+struct SDEProblem{uType,tType,isinplace,P,NP,F,G,K,ND} <: AbstractSDEProblem{uType,tType,isinplace,ND}
   f::F
   g::G
   u0::uType
   tspan::tType
   p::P
   noise::NP
-  callback::C
+  kwargs::K
   noise_rate_prototype::ND
   seed::UInt64
   @add_kwonly function SDEProblem{iip}(f::AbstractSDEFunction{iip},g,u0,
           tspan,p=NullParameters();
           noise_rate_prototype = nothing,
           noise= nothing, seed = UInt64(0),
-          callback = nothing) where {iip}
+          kwargs...) where {iip}
     _tspan = promote_tspan(tspan)
 
     new{typeof(u0),typeof(_tspan),
         isinplace(f),typeof(p),
         typeof(noise),typeof(f),typeof(f.g),
-        typeof(callback),
+        typeof(kwargs),
         typeof(noise_rate_prototype)}(
         f,f.g,u0,_tspan,p,
-        noise,callback,
+        noise,kwargs,
         noise_rate_prototype,seed)
   end
 

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -8,16 +8,18 @@ Defines a steady state problem.
 
 $(FIELDS)
 """
-struct SteadyStateProblem{uType,isinplace,P,F} <: AbstractSteadyStateProblem{uType,isinplace}
+struct SteadyStateProblem{uType,isinplace,P,F,K} <: AbstractSteadyStateProblem{uType,isinplace}
   """f: The function in the ODE."""
   f::F
   """The initial guess for the steady state."""
   u0::uType
   """Parameter values for the ODE function."""
   p::P
+  kwargs::K
   @add_kwonly function SteadyStateProblem{iip}(f::AbstractODEFunction{iip},
-                                               u0,p=NullParameters()) where {iip}
-    new{typeof(u0),isinplace(f),typeof(p),typeof(f)}(f,u0,p)
+                                               u0,p=NullParameters();
+                                               kwargs...) where {iip}
+    new{typeof(u0),isinplace(f),typeof(p),typeof(f),typeof(kwargs)}(f,u0,p,kwargs)
   end
 
   """

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -1,5 +1,5 @@
 @generated function struct_as_namedtuple(st)
-  A = ( Expr(:(=), n, :(st.$n)) for n in fieldnames(st))
+  A = (Expr(:(=), n, :(st.$n)) for n in setdiff(fieldnames(st),(:kwargs,)))
   Expr(:tuple, A...)
 end
 
@@ -23,14 +23,19 @@ arguments.
 """
 function remake(thing; kwargs...)
   T = remaker_of(thing)
-  T(; struct_as_namedtuple(thing)...,kwargs...)
+  @show (thing.kwargs...,kwargs...)
+  if :kwargs ∈ fieldnames(typeof(thing))
+    T(; struct_as_namedtuple(thing)...,thing.kwargs...,kwargs...)
+  else
+    T(; struct_as_namedtuple(thing)...,kwargs...)
+  end
 end
 
 isrecompile(prob::ODEProblem{iip}) where {iip} = (prob.f isa ODEFunction) ? !(typeof(prob.f.f) <: FunctionWrapper) : true
 
 function remake(thing::ODEProblem; kwargs...)
   T = remaker_of(thing)
-  tup = merge(struct_as_namedtuple(thing),kwargs)
+  tup = merge(merge(struct_as_namedtuple(thing),thing.kwargs),kwargs)
   if !isrecompile(thing)
     if isinplace(thing)
       f = wrapfun_iip(unwrap_fw(tup.f.f),(tup.u0,tup.u0,tup.p,tup.tspan[1]))

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -23,7 +23,6 @@ arguments.
 """
 function remake(thing; kwargs...)
   T = remaker_of(thing)
-  @show (thing.kwargs...,kwargs...)
   if :kwargs ∈ fieldnames(typeof(thing))
     T(; struct_as_namedtuple(thing)...,thing.kwargs...,kwargs...)
   else

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -11,15 +11,15 @@ function init(prob::DEProblem,args...;kwargs...)
     isadaptive(alg) &&
     !(typeof(prob) <: NO_TSPAN_PROBS) &&
     adaptive_warn(_prob.u0,_prob.tspan)
-    __init(_prob,alg,args...;kwargs...)
+    __init(_prob,alg,args...;prob.kwargs...,kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
     isadaptive(alg) &&
     !(typeof(prob) <: NO_TSPAN_PROBS) &&
     adaptive_warn(_prob.u0,_prob.tspan)
-    __init(_prob,args...;kwargs...)
+    __init(_prob,args...;prob.kwargs...,kwargs...)
   else
-    __init(_prob,args...;kwargs...)
+    __init(_prob,args...;prob.kwargs...,kwargs...)
   end
 end
 
@@ -30,15 +30,15 @@ function solve(prob::DEProblem,args...;kwargs...)
     isadaptive(alg) &&
     !(typeof(prob) <: NO_TSPAN_PROBS) &&
     adaptive_warn(_prob.u0,_prob.tspan)
-    __solve(_prob,alg,args...;kwargs...)
+    __solve(_prob,alg,args...;prob.kwargs...,kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
     isadaptive(alg) &&
     !(typeof(prob) <: NO_TSPAN_PROBS) &&
     adaptive_warn(_prob.u0,_prob.tspan)
-    __solve(_prob,args...;kwargs...)
+    __solve(_prob,args...;prob.kwargs...,kwargs...)
   else
-    __solve(_prob,args...;kwargs...)
+    __solve(_prob,args...;prob.kwargs...,kwargs...)
   end
 end
 

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -46,14 +46,17 @@ u0 = ones(2)
 tspan = (0,1.0)
 
 # Create a ODEProblem and test remake:
-prob1 = SplitODEProblem(f,f,u0,tspan,Dict())
+prob1 = SplitODEProblem(f,f,u0,tspan,Dict(),callback=nothing)
 prob2 = @inferred remake(prob1; u0 = prob1.u0 .+ 1)
 @test prob1.f === prob2.f
 @test prob1.p === prob2.p
 @test prob1.u0 .+ 1 ≈ prob2.u0
 @test prob1.tspan == prob2.tspan
-@test prob1.callback === prob2.callback
+@test prob1.kwargs[:callback] === prob2.kwargs[:callback]
 @test prob1.problem_type === prob2.problem_type
+
+prob2 = @inferred remake(prob1; u0 = prob1.u0 .+ 1, callback = :test)
+@test prob2.kwargs[:callback] == :test
 
 # Test remake with SplitFunction:
 prob1 = SplitODEProblem((u,p,t) -> u/2, (u,p,t) -> 2u, 1.0, (0.0,1.0))


### PR DESCRIPTION
This is a multiple birds in one stone fix. In Pumas I realized it would be easier to use the Ensemble interface if I could add a tstop to the Ensemble. The fact that `callback` was in the problem always kind of annoyed me because it was an odd one out. Using `prob` remake stuff for parameter estimation couldn't handle possibly changing arguments like `d_discontinuities`. etc.

But if a `DEProblem` now captures the `kwargs`, then all of these are handled. In the higher level functions we just splat them in with the other `kwargs` and none of the solvers need to even explicitly handle this. `callback` is then automatically handled because it's a standard common interface argument.