### PR TITLE
`is_constant` -> `isconstant`

### DIFF
--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -46,7 +46,7 @@ Base.size(::DiffEqScalar) = ()
 Base.size(::DiffEqScalar, ::Integer) = 1
 update_coefficients!(α::DiffEqScalar,u,p,t) = (α.val = α.update_func(α.val,u,p,t); α)
 setval!(α::DiffEqScalar, val) = (α.val = val; α)
-is_constant(α::DiffEqScalar) = α.update_func == DEFAULT_UPDATE_FUNC
+isconstant(α::DiffEqScalar) = α.update_func == DEFAULT_UPDATE_FUNC
 
 for op in (:*, :/, :\)
   @eval Base.$op(α::DiffEqScalar, x::Union{AbstractArray,Number}) = $op(α.val, x)
@@ -87,7 +87,7 @@ end
 
 update_coefficients!(L::DiffEqArrayOperator,u,p,t) = (L.update_func(L.A,u,p,t); L)
 setval!(L::DiffEqArrayOperator, A) = (L.A = A; L)
-is_constant(L::DiffEqArrayOperator) = L.update_func == DEFAULT_UPDATE_FUNC
+isconstant(L::DiffEqArrayOperator) = L.update_func == DEFAULT_UPDATE_FUNC
 
 Base.convert(::Type{AbstractMatrix}, L::DiffEqArrayOperator) = L.A
 Base.setindex!(L::DiffEqArrayOperator, v, i::Int) = (L.A[i] = v)

--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -1,6 +1,6 @@
 # The `update_coefficients!` interface
 DEFAULT_UPDATE_FUNC(A,u,p,t) = A # no-op used by the basic operators
-# is_constant(::AbstractDiffEqLinearOperator) = true # already defined in DiffEqBase
+# isconstant(::AbstractDiffEqLinearOperator) = true # already defined in DiffEqBase
 update_coefficients!(L::AbstractDiffEqLinearOperator,u,p,t) = L
 
 # Routines that use the AbstractMatrix representation

--- a/src/operators/diffeq_operator.jl
+++ b/src/operators/diffeq_operator.jl
@@ -33,7 +33,7 @@ has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 2. Can absorb under multiplication by a scalar. In all algorithms things like
    dt*L show up all the time, so the linear operator must be able to absorb
    such constants.
-4. is_constant(A) trait for whether the operator is constant or not.
+4. isconstant(A) trait for whether the operator is constant or not.
 5. Optional: diagonal, symmetric, etc traits from LinearMaps.jl.
 6. Optional: exp(A). Required for simple exponential integration.
 7. Optional: expmv(A,u,p,t) = exp(t*A)*u and expmv!(v,A::DiffEqOperator,u,p,t)
@@ -45,7 +45,7 @@ has_ldiv!(L::AbstractDiffEqOperator) = false # ldiv!(du, L, u)
 
 # Extra standard assumptions
 isconstant(::AbstractDiffEqLinearOperator) = true
-islinear(::AbstractDiffEqLinearOperator) = true
+islinear(o::AbstractDiffEqLinearOperator) = isconstant(o)
 
 # Other ones from LinearMaps.jl
 # Generic fallbacks

--- a/test/basic_operators_interface.jl
+++ b/test/basic_operators_interface.jl
@@ -15,7 +15,7 @@ end
   @test α * u == 2.0u
   lmul!(α, u2); @test u2 == 2.0u
   @test size(α) == ()
-  @test is_constant(α) == true
+  @test isconstant(α) == true
 end
 
 @testset "Array Operators" begin
@@ -29,7 +29,7 @@ end
   @test opnorm(L) == opnorm(A)
   @test exp(L) == exp(A)
   @test L[1,2] == A[1,2]
-  @test is_constant(L) == true
+  @test isconstant(L) == true
 end
 
 @testset "Mutable Array Operators" begin
@@ -37,7 +37,7 @@ end
   update_func = (_A,u,p,t) -> _A .= t * A
   Lt = DiffEqArrayOperator(zeros(2,2); update_func=update_func)
   t = 5.0
-  @test is_constant(Lt) == false
+  @test isconstant(Lt) == false
   @test Lt(u,nothing,t) ≈ (t*A) * u
   Lt(du,u,nothing,t); @test du ≈ (t*A) * u
 end


### PR DESCRIPTION
https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/835254896f9b97669edfe3a28362ed8978b6c0e9/src/operators/diffeq_operator.jl#L126 has been there for a while. This PR renames `is_constant` to `isconstant`. Also, it directs `islinear` to `isconstant`.