### PR TITLE
GPU test not broken anymore

### DIFF
--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -32,8 +32,7 @@ prob_nojac = ODEProblem(f,u0,tspan)
 @test_broken solve(prob_nojac,Rosenbrock23()).retcode == :Success
 @test solve(prob_nojac,Rosenbrock23(autodiff=false)).retcode == :Success
 @test solve(prob_nojac,Rosenbrock23(autodiff=false,diff_type = Val{:central})).retcode == :Success
-# hits a generic matmul fallback
-@test_broken solve(prob_nojac,Rosenbrock23(autodiff=false,diff_type = Val{:complex})).retcode == :Success
+@test solve(prob_nojac,Rosenbrock23(autodiff=false,diff_type = Val{:complex})).retcode == :Success
 
 prob_nojac_oop = ODEProblem{false}(f,u0,tspan)
 @test_broken solve(prob_nojac_oop,Rosenbrock23()).retcode == :Success


### PR DESCRIPTION
Apparently one of the GPU tests is not broken anymore: https://gitlab.com/juliadiffeq/OrdinaryDiffEq-jl/-/jobs/351952429