### PR TITLE
Allowing solve.jl to merge user defined callbacks with those defined …

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -35,6 +35,12 @@ end
 
 function solve_call(_prob,args...;kwargs...)
   if :kwargs ∈ propertynames(_prob)
+    if haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+      kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
+      values(kwargs)), (:callback,))}(values(kwargs))
+      callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs.callback, values(kwargs).callback )] )
+      kwargs = merge(kwargs_temp, callbacks)
+    end
     __solve(_prob,args...;_prob.kwargs...,kwargs...)
   else
     __solve(_prob,args...;kwargs...)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -33,9 +33,9 @@ function init(prob::DEProblem,args...;kwargs...)
   end
 end
 
-function solve_call(_prob,args...;kwargs...)
+function solve_call(_prob,args...;merge_callbacks = true,kwargs...)
   if :kwargs ∈ propertynames(_prob)
-    if haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+    if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
       values(kwargs)), (:callback,))}(values(kwargs))
       callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs.callback, values(kwargs).callback )] )


### PR DESCRIPTION
…in the problem.

As discussed on Slack, this PR allows `_prob`-defined callbacks to be merged with those supplied by the user.
The merge is done by defining a `CallbackSet` comprised of both the `_prob` callbacks and the user defined callbacks.