### PR TITLE
add Zygote and ChainRules adjoint rules to the ODEFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "6.10.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqDiffTools = "01453d9d-ee7c-5054-8395-0335cb756afa"

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -5,7 +5,7 @@ using RecipesBase, RecursiveArrayTools, Compat,
       IterativeSolvers, RecursiveFactorization, Distributed, ArrayInterface,
       DataStructures
 
-import ZygoteRules
+import ZygoteRules, ChainRulesCore
 
 using Roots # callbacks
 

--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -66,4 +66,5 @@ function ChainRulesCore.rrule(f::ODEFunction,u,p,t)
     ChainRulesCore.rrule(f.f,u,p,t)
   else
     f.vjp(u,p,t)
+  end
 end

--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -35,13 +35,9 @@ end
 
 ZygoteRules.@adjoint function (f::ODEFunction)(u,p,t)
   if f.vjp === nothing
-    out = f.f(u,p,t)
     ZygoteRules.adjoint(f.f,u,p,t)
   else
-    function ode_vjp(d)
-      f.vjp(d,u,p,t)
-    end
-    return out,ode_vjp
+    f.vjp(u,p,t)
   end
 end
 
@@ -50,10 +46,6 @@ ZygoteRules.@adjoint! function (f::ODEFunction)(du,u,p,t)
     ZygoteRules.adjoint!(f.f,du,u,p,t)
   else
     f.f(du,u,p,t)
-    function ode_vjp(d)
-      f.vjp(du,d,u,p,t)
-    end
-    return nothing,ode_vjp
   end
 end
 
@@ -73,8 +65,5 @@ ChainRulesCore.rrule(f::ODEFunction,u,p,t)
   if f.vjp === nothing
     ChainRulesCore.rrule(f.f,u,p,t)
   else
-    function ode_vjp(f,d)
-      f.vjp(d,u,p,t)
-    end
-    f.f(u,p,t),ode_jvp
+    f.vjp(u,p,t)
 end

--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -61,7 +61,7 @@ ChainRulesCore.frule(f::ODEFunction,u,p,t)
 end
 =#
 
-ChainRulesCore.rrule(f::ODEFunction,u,p,t)
+function ChainRulesCore.rrule(f::ODEFunction,u,p,t)
   if f.vjp === nothing
     ChainRulesCore.rrule(f.f,u,p,t)
   else

--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -1,4 +1,4 @@
-function ZygoteRules.@adjoint ODESolution(u,args...)
+ZygoteRules.@adjoint function ODESolution(u,args...)
   function ODESolutionAdjoint(ȳ)
     (ȳ,ntuple(_->nothing, length(args))...)
   end

--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -1,27 +1,80 @@
-ZygoteRules.@adjoint ODESolution(u,args...) = ODESolution(u,args...), ȳ -> (ȳ,ntuple(_->nothing, length(args))...)
+function ZygoteRules.@adjoint ODESolution(u,args...)
+  function ODESolutionAdjoint(ȳ)
+    (ȳ,ntuple(_->nothing, length(args))...)
+  end
+  ODESolution(u,args...), ODESolutionAdjoint
+end
 
 ZygoteRules.@adjoint function ODESolution{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11
                 }(u,args...) where {T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11}
 
-                f = function (ȳ)
+                function ODESolutionAdjoint(ȳ)
                   (ȳ,ntuple(_->nothing, length(args))...)
                 end
 
-                ODESolution{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11}(u,args...),f
+                ODESolution{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11}(u,args...),ODESolutionAdjoint
 end
 
 ZygoteRules.@adjoint function getindex(sol::DESolution, i)
-  sol[i], function (Δ)
+  function DESolution_getindex_adjoint(Δ)
     Δ′ = Union{Nothing, eltype(sol.u)}[nothing for x in sol.u]
     Δ′[i] = Δ
     (Δ′,nothing)
   end
+  sol[i],DESolution_getindex_adjoint
 end
 
 ZygoteRules.@adjoint function getindex(sol::DESolution, i, j...)
-  sol[i,j...], function (Δ)
+  function DESolution_getindex_adjoint(Δ)
     Δ′ = zero(sol)
     Δ′[i,j...] = Δ
     (Δ′, map(_ -> nothing, i)...)
   end
+  sol[i,j...],DESolution_getindex_adjoint
+end
+
+ZygoteRules.@adjoint function (f::ODEFunction)(u,p,t)
+  if f.vjp === nothing
+    out = f.f(u,p,t)
+    ZygoteRules.adjoint(f.f,u,p,t)
+  else
+    function ode_vjp(d)
+      f.vjp(d,u,p,t)
+    end
+    return out,ode_vjp
+  end
+end
+
+ZygoteRules.@adjoint! function (f::ODEFunction)(du,u,p,t)
+  if f.vjp === nothing
+    ZygoteRules.adjoint!(f.f,du,u,p,t)
+  else
+    f.f(du,u,p,t)
+    function ode_vjp(d)
+      f.vjp(du,d,u,p,t)
+    end
+    return nothing,ode_vjp
+  end
+end
+
+#=
+ChainRulesCore.frule(f::ODEFunction,u,p,t)
+  if f.jvp === nothing
+    ChainRulesCore.frule(f.f,u,p,t)
+  else
+    function ode_jvp(f,du,dp,dt)
+      f.jvp_u(du,u,p,t) + f.jvp_p(dp,u,p,t) + f.tgrad(u,p,t)*dt
+    end
+    f.f(u,p,t),ode_jvp
+end
+=#
+
+ChainRulesCore.rrule(f::ODEFunction,u,p,t)
+  if f.vjp === nothing
+    ChainRulesCore.rrule(f.f,u,p,t)
+  else
+    function ode_vjp(f,d)
+      f.vjp(d,u,p,t)
+    end
+    f.f(u,p,t),ode_jvp
 end


### PR DESCRIPTION
@YingboMa I realized that this would make it fairly clean and easy for the DiffEqSensitivity implementations, since now it doesn't have to have a branch to handle the existence of a vjp but is just built into the `autojacvec` implementation once it's Zygote.

@oxinabox this commented part is what I mean though, where in the sensitivity analysis implementations I want to calculate `df/du *v`for `f(u,p,t)`, but there doesn't seem an idea for that Jacobian-vector product in ChainRules. It's not issue though an easy to work around, but food for thought.