### PR TITLE
Simplify `promote_tspan`

### DIFF
--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -4,11 +4,7 @@
 Convert the `tspan` field of a `DEProblem` to a `(tmin, tmax)` tuple, where both
 elements are of the same type. If `tspan` is a function, returns it as-is.
 """
-promote_tspan(tspan::Tuple{T,T}) where T = tspan
-function promote_tspan(tspan::Tuple{T1,T2}) where {T1,T2}
-  T = promote_type(map(typeof,tspan)...)
-  (map(T,tspan)...,)
-end
+promote_tspan((t1,t2)::Tuple{T,S}) where {T,S} = promote(t1, t2)
 promote_tspan(tspan::Number) = (zero(tspan),tspan)
 promote_tspan(tspan::Nothing) = (nothing,nothing)
 promote_tspan(tspan::Function) = tspan


### PR DESCRIPTION
Master

```julia
julia> Zygote.gradient(x->sum(ODEProblem{true}((u,p,t)->u, x, (0, 1.0)).u0), ones(5))
ERROR: MethodError: no method matching length(::Nothing)
Closest candidates are:
  length(::Core.SimpleVector) at essentials.jl:593
  length(::Base.MethodList) at reflection.jl:849
  length(::Core.MethodTable) at reflection.jl:923
  ...
Stacktrace:
 [1] unzip(::Tuple{Nothing,Nothing}) at /home/scheme/.julia/packages/Zygote/fw4Oc/src/lib/array.jl:125
 [2] (::Zygote.var"#1110#1114"{Tuple{Zygote.var"#45#64",Zygote.var"#45#64"}})(::Tuple{Nothing,Nothing}) at /home/scheme/.julia/packages/Zygote/fw4Oc/src/lib/array.jl:137
 [3] (::Zygote.var"#2878#back#1116"{Zygote.var"#1110#1114"{Tuple{Zygote.var"#45#64",Zygote.var"#45#64"}}})(::Tuple{Nothing,Nothing}) at /home/scheme/.julia/packages/ZygoteRules/6nssF/src/adjoint.jl:49
 [4] promote_tspan at /home/scheme/.julia/packages/DiffEqBase/8fdjX/src/problems/problem_utils.jl:9 [inlined]
...
```

PR

```julia
julia> Zygote.gradient(x->sum(ODEProblem{false}((u,p,t)->u, x, (0, 1.0)).u0), ones(5))
([1.0, 1.0, 1.0, 1.0, 1.0],)
```