### PR TITLE
Fix the default norm on duals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,6 +54,7 @@ julia = "1"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -61,4 +62,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Distributions", "Pkg", "Random", "SafeTestsets", "InteractiveUtils"]
+test = ["Test", "Distributions", "Pkg", "Random", "SafeTestsets", "InteractiveUtils", "ForwardDiff"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.14.0"
+version = "6.14.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/init.jl
+++ b/src/init.jl
@@ -25,22 +25,12 @@ function __init__()
     @inline fastpow(x::ForwardDiff.Dual, y::ForwardDiff.Dual) = x^y
 
     # Support adaptive with non-dual time
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N},t) where {N}
-      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))) / length(u))
-    end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:ForwardDiff.Dual,N},t) where {N}
-      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((value(x) for x in u),Iterators.repeated(t))) / length(u))
-    end
-    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,t) = abs(value(u))
+    @inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(UNITLESS_ABS2∘value,u) / length(u))
+    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::Any) = abs(value(u))
 
     # When time is dual, it shouldn't drop the duals for adaptivity
-    @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual,N},t::ForwardDiff.Dual) where {N}
-      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((x for x in u),Iterators.repeated(t))) / length(u))
-    end
-    @inline function ODE_DEFAULT_NORM(u::Array{<:ForwardDiff.Dual,N},t::ForwardDiff.Dual) where {N}
-      sqrt(sum(x->ODE_DEFAULT_NORM(x[1],x[2]),zip((x for x in u),Iterators.repeated(t))) / length(u))
-    end
-    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,t::ForwardDiff.Dual) = abs(u)
+    @inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},::ForwardDiff.Dual) = sqrt(sum(UNITLESS_ABS2,u) / length(u))
+    @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::ForwardDiff.Dual) = abs(u)
 
     # Type piracy. Should upstream
     Base.nextfloat(d::ForwardDiff.Dual{T,V,N}) where {T,V,N} = ForwardDiff.Dual{T}(nextfloat(d.value), d.partials)

--- a/test/norm.jl
+++ b/test/norm.jl
@@ -1,5 +1,5 @@
 using Test
-using ForwardDiff: Dual
+using ForwardDiff: Dual, gradient, partials
 
 using DiffEqBase: ODE_DEFAULT_NORM
 const internalnorm = ODE_DEFAULT_NORM
@@ -7,4 +7,9 @@ const internalnorm = ODE_DEFAULT_NORM
 val = rand(10)
 par = rand(10)
 u = Dual.(val, par)
-@test internalnorm(val, 1) == internalnorm(u, 1)
+reference = internalnorm(val, 1)
+dual_real = internalnorm(u, 1)
+dual_dual = internalnorm(u, u[1])
+@test reference === dual_real
+@test reference == dual_dual
+@test partials(dual_dual, 1) ≈ gradient(x->internalnorm(x, x[1]), val)'par

--- a/test/norm.jl
+++ b/test/norm.jl
@@ -1,0 +1,10 @@
+using Test
+using ForwardDiff: Dual
+
+using DiffEqBase: ODE_DEFAULT_NORM
+const internalnorm = ODE_DEFAULT_NORM
+
+val = rand(10)
+par = rand(10)
+u = Dual.(val, par)
+@test internalnorm(val, 1) == internalnorm(u, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ if GROUP == "All" || GROUP == "Core"
     @time @safetestset "Internal Euler" begin include("internal_euler_test.jl") end
     @time @safetestset "Numargs" begin include("numargs_test.jl") end
     @time @safetestset "Basic Operators Interface" begin include("basic_operators_interface.jl") end
+    @time @safetestset "Norm" begin include("norm.jl") end
 end
 
 if !is_APPVEYOR && GROUP == "Downstream"


### PR DESCRIPTION
We want the tests in https://github.com/JuliaDiffEq/DiffEqBase.jl/compare/myb/dual_norm?expand=1#diff-b7439ee44628e4b8309362bed2cb652b to pass to make sure that the time adaptivity hits the same points.