### PR TITLE
Add missing method for timedepentdtmin

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.17.0"
+version = "6.17.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -252,4 +252,5 @@ prob2dtmin(tspan, ::Integer, ::Any) = 0
 prob2dtmin(tspan, ::Any, ::Any) = convert(eltype(tspan), 1//10^(10))
 
 timedepentdtmin(integrator::DEIntegrator) = timedepentdtmin(integrator.t, integrator.opts.dtmin)
-timedepentdtmin(t, dtmin) = abs(max(eps(t), dtmin))
+timedepentdtmin(t::AbstractFloat, dtmin) = abs(max(eps(t), dtmin))
+timedepentdtmin(::Any, dtmin) = abs(dtmin)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,4 +15,5 @@ using DiffEqBase: prob2dtmin, timedepentdtmin
   @test_throws ArgumentError tspan2dtmin((Inf, 100.0))
   @test tspan2dtmin((0f0, 1f5); use_end_time=false) === eps(1f0)
   @test timedepentdtmin(10f0, eps(1f0)) === eps(10f0)
+  @test timedepentdtmin(10, eps(1f0)) === eps(1f0)
 end


### PR DESCRIPTION
Fix CI failures in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/1045