### PR TITLE
promote u0 and tspan to auto-fix autodiff bugs

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -151,11 +151,11 @@ multiple events.
 - `condition`: This is a function `condition(out, u, t, integrator)` which should save the condition value in the array `out`
    at the right index. Maximum index of `out` should be specified in the `len` property of callback. So this way you can have
    a chain of `len` events, which would cause the `i`th event to trigger when `out[i] = 0`.
-- `affect!`: This is a function `affect!(integrator, event_index)` which lets you modify `integrator` and it tells you about 
+- `affect!`: This is a function `affect!(integrator, event_index)` which lets you modify `integrator` and it tells you about
    which event occured using `event_idx` i.e. gives you index `i` for which `out[i]` came out to be zero.
 - `len`: Number of callbacks chained. This is compulsory to be specified.
 
-Rest of the arguments have the same meaning as in [`ContinuousCallback`](@ref). 
+Rest of the arguments have the same meaning as in [`ContinuousCallback`](@ref).
 """
 struct VectorContinuousCallback{F1,F2,F3,F4,T,T2,I} <: AbstractContinuousCallback
   condition::F1
@@ -320,6 +320,10 @@ end
 Base.isempty(cb::CallbackSet) = isempty(cb.continuous_callbacks) && isempty(cb.discrete_callbacks)
 Base.isempty(cb::AbstractContinuousCallback) = false
 Base.isempty(cb::AbstractDiscreteCallback) = false
+
+has_continuous_callback(cb::DiscreteCallback) = false
+has_continuous_callback(cb::ContinuousCallback) = true
+has_continuous_callback(cb::CallbackSet) = !isempty(cb.continuous_callbacks)
 
 #======================================================#
 # Callback handling

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -91,6 +91,7 @@ end
 
 function get_concrete_problem(prob::AbstractSteadyStateProblem, kwargs)
   u0 = get_concrete_u0(prob, Inf, kwargs)
+  u0 = promote_u0(u0, prob.p, nothing)
   remake(prob; u0 = u0)
 end
 
@@ -108,6 +109,8 @@ function discretize end
 function get_concrete_problem(prob, kwargs)
   tspan = get_concrete_tspan(prob, kwargs)
   u0 = get_concrete_u0(prob, tspan[1], kwargs)
+  u0 = promote_u0(u0, prob.p, tspan[1])
+  tspan = promote_tspan(u0, prob.p, tspan, prob, kwargs)
   remake(prob; u0 = u0, tspan = tspan)
 end
 
@@ -121,6 +124,9 @@ function get_concrete_problem(prob::DDEProblem, kwargs)
   else
     constant_lags = prob.constant_lags
   end
+
+  u0 = promote_u0(u0, prob.p, tspan[1])
+  tspan = promote_tspan(u0, prob.p, tspan, prob, kwargs)
 
   remake(prob; u0 = u0, tspan = tspan, constant_lags = constant_lags)
 end


### PR DESCRIPTION
We know these are common pitfalls: here's a system to work around it. For now it won't be documented so we can keep improving it.